### PR TITLE
Cloud Databases: Add instance.get_disk_usage()

### DIFF
--- a/pyrax/cloud_databases.py
+++ b/pyrax/cloud_databases.py
@@ -203,6 +203,14 @@ class CloudDatabaseInstance(BaseResource):
         body = {"volume": {"size": size}}
         self.manager.action(self, "resize", body=body)
 
+    def get_disk_usage(self):
+        """Get the disk usage of this instance."""
+        if self.volume.get("used"):
+            return self.volume.get("used")
+        else:
+            uri = "/instances/%s" % self.id
+            resp, body = self.manager.api.method_get(uri)
+            return body['instance']['volume']['used']
 
     def _get_flavor(self):
         try:


### PR DESCRIPTION
I've been searching for a way to get the disk usage of a Cloud DB instance. The information returned by an instance listing only contains the volume size, not the usage value:

``` python
>>> import os
>>> import pyrax
>>> pyrax.set_credential_file(os.path.expanduser("~/.rackspace_cloud_credentials"))
>>> cdb = pyrax.connect_to_cloud_databases(region='ORD')
>>> instance = cdb.list()[0]
>>> print instance.volume
{u'size': 1}
```

With this patch:

``` python
>>> import os
>>> import pyrax
>>> pyrax.set_credential_file(os.path.expanduser("~/.rackspace_cloud_credentials"))
>>> cdb = pyrax.connect_to_cloud_databases(region='ORD')
>>> instance = cdb.list()[0]
>>> print instance.volume
{u'size': 1}
>>> print instance.get_disk_usage()
0.141017913818
```

If there's another way to get disk usage without this patch I'd love to know because I suspect its staring me in the face.
