### PR TITLE
container stats should be integers

### DIFF
--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -17,8 +17,8 @@ class Container(object):
     def __init__(self, client, name, object_count=None, total_bytes=None):
         self.client = client
         self.name = name
-        self.object_count = object_count
-        self.total_bytes = total_bytes
+        self.object_count = int(object_count)
+        self.total_bytes = int(total_bytes)
         self._cdn_uri = FAULT
         self._cdn_ttl = FAULT
         self._cdn_ssl_uri = FAULT


### PR DESCRIPTION
it's cumbersome to have to convert something that should always be a number into a number in order to do math with it on my application.
