### PR TITLE
NameError: global name 'self' is not defined

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -189,7 +189,7 @@ def set_credentials(username, api_key, region=None, authenticate=True):
         clear_credentials()
         raise
     if region:
-        self.default_region = region
+        default_region = region
     if identity.authenticated:
         connect_to_services(region=region)
 


### PR DESCRIPTION
pyrax/**init**.py", line 192, in set_credentials
    self.default_region = region
NameError: global name 'self' is not defined
