### PR TITLE
iOS URI support in Cloud Files

### DIFF
--- a/docs/cloud_files.md
+++ b/docs/cloud_files.md
@@ -421,6 +421,7 @@ Once a container is made public, you can access its CDN-related properties. You 
     print "cdn_uri", cont.cdn_uri
     print "cdn_ssl_uri", cont.cdn_ssl_uri
     print "cdn_streaming_uri", cont.cdn_streaming_uri
+    print "cdn_ios_uri", cont.cdn_ios_uri
 
     # Make it public
     cont.make_public(ttl=1200)
@@ -435,6 +436,7 @@ Once a container is made public, you can access its CDN-related properties. You 
     print "cdn_uri", cont.cdn_uri
     print "cdn_ssl_uri", cont.cdn_ssl_uri
     print "cdn_streaming_uri", cont.cdn_streaming_uri
+    print "cdn_ios_uri", cont.cdn_ios_uri
 
     # clean up
     cont.delete()
@@ -448,6 +450,7 @@ Running this returns the following:
     cdn_uri None
     cdn_ssl_uri None
     cdn_streaming_uri None
+    cdn_ios_uri None
 
     After Making Public
     cdn_enabled True
@@ -456,6 +459,7 @@ Running this returns the following:
     cdn_uri http://6cface6ba364a8b14147-0a7948bc1fe3dbb60c24b92b61e4818f.r83.cf1.rackcdn.com
     cdn_ssl_uri https://8f03601ca5bfb714a8b2-0a7948bc1fe3dbb60c24b92b61e4818f.ssl.cf1.rackcdn.com
     cdn_streaming_uri http://882ea271eef0a907997b-0a7948bc1fe3dbb60c24b92b61e4818f.r83.stream.cf1.rackcdn.com
+    cdn_ios_uri http://797722bf130f8afc2538-5a91ce4f079965bd7f8a88a0a2a855cb.iosr.cf3.rackcdn.com
 
 To remove a container from the public CDN, simply call:
 

--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -939,6 +939,12 @@ class CFClient(object):
         return cont.cdn_streaming_uri
 
 
+    def get_container_ios_uri(self, container):
+        """Returns the iOS URI, or None if CDN is not enabled."""
+        cont = self.get_container(container)
+        return cont.cdn_ios_uri
+
+
     def set_container_web_index_page(self, container, page):
         """
         Sets the header indicating the index page in a container

--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -40,6 +40,7 @@ class Container(object):
         self._cdn_ttl = FAULT
         self._cdn_ssl_uri = FAULT
         self._cdn_streaming_uri = FAULT
+        self._cdn_ios_uri = FAULT
         self._cdn_log_retention = FAULT
         self._object_cache = {}
 
@@ -50,6 +51,7 @@ class Container(object):
         self._cdn_ttl = self.client.default_cdn_ttl
         self._cdn_ssl_uri = None
         self._cdn_streaming_uri = None
+        self._cdn_ios_uri = None
         self._cdn_log_retention = False
 
 
@@ -69,6 +71,8 @@ class Container(object):
                     self._cdn_ssl_uri = hdr[1]
                 elif low_hdr == "x-cdn-streaming-uri":
                     self._cdn_streaming_uri = hdr[1]
+                elif low_hdr == "x-cdn-ios-uri":
+                    self._cdn_ios_uri = hdr[1]
                 elif low_hdr == "x-log-retention":
                     self._cdn_log_retention = (hdr[1] == "True")
         elif response.status == 404:
@@ -319,9 +323,19 @@ class Container(object):
         self._cdn_streaming_uri = val
 
 
+    def _get_cdn_ios_uri(self):
+        if self._cdn_ios_uri is FAULT:
+            self._fetch_cdn_data()
+        return self._cdn_ios_uri
+
+    def _set_cdn_ios_uri(self, val):
+        self._cdn_ios_uri = val
+
+
     cdn_log_retention = property(_get_cdn_log_retention, _set_cdn_log_retention)
     cdn_uri = property(_get_cdn_uri, _set_cdn_uri)
     cdn_ttl = property(_get_cdn_ttl, _set_cdn_ttl)
     cdn_ssl_uri = property(_get_cdn_ssl_uri, _set_cdn_ssl_uri)
     cdn_streaming_uri = property(_get_cdn_streaming_uri, _set_cdn_streaming_uri)
+    cdn_ios_uri = property(_get_cdn_ios_uri, _set_cdn_ios_uri)
     ## END - CDN property definitions ##

--- a/samples/cloudfiles/container_cdn.py
+++ b/samples/cloudfiles/container_cdn.py
@@ -33,6 +33,7 @@ print "cdn_log_retention", cont.cdn_log_retention
 print "cdn_uri", cont.cdn_uri
 print "cdn_ssl_uri", cont.cdn_ssl_uri
 print "cdn_streaming_uri", cont.cdn_streaming_uri
+print "cdn_ios_uri", cont.cdn_ios_uri
 
 # Make it public
 cont.make_public(ttl=1200)
@@ -47,6 +48,7 @@ print "cdn_log_retention", cont.cdn_log_retention
 print "cdn_uri", cont.cdn_uri
 print "cdn_ssl_uri", cont.cdn_ssl_uri
 print "cdn_streaming_uri", cont.cdn_streaming_uri
+print "cdn_ios_uri", cont.cdn_ios_uri
 
 # clean up
 cont.delete()

--- a/tests/unit/fakes.py
+++ b/tests/unit/fakes.py
@@ -63,6 +63,7 @@ class FakeContainer(Container):
         self._cdn_ttl = self.client.default_cdn_ttl
         self._cdn_ssl_uri = None
         self._cdn_streaming_uri = None
+        self._cdn_ios_uri = None
         self._cdn_log_retention = False
 
 

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -693,6 +693,15 @@ class CF_ClientTest(unittest.TestCase):
         self.assertEqual(uri, example_uri)
 
     @patch('pyrax.cf_wrapper.client.Container', new=FakeContainer)
+    def test_get_container_ios_uri(self):
+        client = self.client
+        client.connection.head_container = Mock()
+        example_uri = "http://example.com"
+        client.get_container(self.cont_name).cdn_ios_uri = example_uri
+        uri = client.get_container_ios_uri(self.cont_name)
+        self.assertEqual(uri, example_uri)
+
+    @patch('pyrax.cf_wrapper.client.Container', new=FakeContainer)
     def test_list_containers(self):
         client = self.client
         client.connection.get_container = Mock()

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -72,10 +72,12 @@ class CF_ContainerTest(unittest.TestCase):
         test_ttl = "6666"
         test_ssl_uri = "http://ssl.example.com"
         test_streaming_uri = "http://streaming.example.com"
+        test_ios_uri = "http://ios.example.com"
         test_log_retention = True
         resp.getheaders.return_value = [("x-cdn-uri", test_uri),
                 ("x-ttl", test_ttl), ("x-cdn-ssl-uri", test_ssl_uri),
                 ("x-cdn-streaming-uri", test_streaming_uri),
+                ("x-cdn-ios-uri", test_ios_uri),
                 ("x-log-retention", test_log_retention)]
         self.client.connection.cdn_request.return_value = resp
         # We need an actual container
@@ -91,6 +93,7 @@ class CF_ContainerTest(unittest.TestCase):
         test_ttl = "6666"
         test_ssl_uri = "http://ssl.example.com"
         test_streaming_uri = "http://streaming.example.com"
+        test_ios_uri = "http://ios.example.com"
         test_log_retention = True
         resp.getheaders.return_value = []
         self.client.connection.cdn_request.return_value = resp


### PR DESCRIPTION
Cloud Files added iOS streaming support in order to avoid video conversion for relevant devices.
http://docs.rackspace.com/files/api/v1/cf-devguide/content/iOS-Streaming-d1f3725.html
