### PR TITLE
Added existing user addition to / removal from existing databases support

### DIFF
--- a/pyrax/clouddatabases.py
+++ b/pyrax/clouddatabases.py
@@ -253,6 +253,22 @@ class CloudDatabaseInstance(BaseResource):
 
     flavor = property(_get_flavor, _set_flavor)
 
+    def grant_access(self, user, database):
+        """
+        Grant a user access to a database.
+        user is the name of the user and database is the name of the database.
+        """
+        self.manager.api.method_put(("/instances/%s/users/%s/databases"
+            % (self.id, user)), body={"databases": [{"name": database}]})
+
+    def revoke_access(self, user, database):
+        """
+        Revoke a user's access to a database
+        user is the name of the user and database is the name of the database.
+        """
+        self.manager.api.method_delete(("/instances/%s/users/%s/databases/%s"
+            % (self.id, user, database)))
+
 
 class CloudDatabaseDatabase(BaseResource):
     """
@@ -265,6 +281,7 @@ class CloudDatabaseDatabase(BaseResource):
     def delete(self):
         """This class doesn't have an 'id', so pass the name."""
         self.manager.delete(self.name)
+
 
 
 class CloudDatabaseUser(BaseResource):

--- a/tests/unit/test_cloud_databases.py
+++ b/tests/unit/test_cloud_databases.py
@@ -219,6 +219,26 @@ class CloudDatabasesTest(unittest.TestCase):
         inst.flavor = flavor
         self.assertTrue(isinstance(inst.flavor, CloudDatabaseFlavor))
 
+    def test_grant_access(self):
+        inst = self.instance
+        user = utils.random_name()
+        database = utils.random_name()
+        inst.manager.api.method_put = Mock()
+        ret = inst.grant_access(user, database)
+        call_uri = "/instances/%s/users/%s/databases" % (inst.id, user)
+        body = {"databases": [{"name": database}]}
+        inst.manager.api.method_put.assert_called_once_with(call_uri, body=body)
+
+    def test_revoke_access(self):
+        inst = self.instance
+        user = utils.random_name()
+        database = utils.random_name()
+        inst.manager.api.method_delete = Mock()
+        ret = inst.revoke_access(user, database)
+        call_uri = "/instances/%s/users/%s/databases/%s" % (inst.id, user, database)
+        inst.manager.api.method_delete.assert_called_once_with(call_uri)
+
+
     @patch("pyrax.manager.BaseManager", new=fakes.FakeManager)
     def test_list_databases_for_instance(self):
         clt = self.client


### PR DESCRIPTION
Includes 2 methods in the CloudDatabaseInstance class, and 2 corresponding unit tests.
