### PR TITLE
Addressing CloudFiles client get_temp_url returning wrong url

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -208,7 +208,7 @@ class CFClient(object):
         base_url = conn_url[:v1pos]
         path_parts = (conn_url[v1pos:], cname, oname)
         cleaned = (part.strip("/\\") for part in path_parts)
-        pth = "/".join(cleaned)
+        pth = "/%s" % "/".join(cleaned)
         if isinstance(pth, unicode):
             pth = pth.encode(pyrax.encoding)
         expires = int(time.time() + int(seconds))


### PR DESCRIPTION
The leading slash was being removed during the "cleaning", this way it is readded. This caused a wrong signing of the request as the hash must be generated with the full url (everything after the base url). It's better to keep cleaning it as the other slashes are readded later in te original code.
