### PR TITLE
Addressing CloudFiles client get_temp_url returning wrong url issue #60

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -208,7 +208,7 @@ class CFClient(object):
         base_url = conn_url[:v1pos]
         path_parts = (conn_url[v1pos:], cname, oname)
         cleaned = (part.strip("/\\") for part in path_parts)
-        pth = "/".join(cleaned)
+        pth = "/%s" % "/".join(cleaned)
         if isinstance(pth, unicode):
             pth = pth.encode(pyrax.encoding)
         expires = int(time.time() + int(seconds))


### PR DESCRIPTION
CloudFiles wrapper returns a wrong temp_url because of the stripping of slashes:
https://storage101.ord1.clouddrive.comv1/MossoCloudFS_

this patches the .comv1 problem to .com/v1
