### PR TITLE
add headers argument to upload_file and store_object

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -422,7 +422,7 @@ class CFClient(object):
 
     @handle_swiftclient_exception
     def store_object(self, container, obj_name, data, content_type=None,
-            etag=None):
+            etag=None, headers=None):
         """
         Creates a new object in the specified container, and populates it with
         the given data.
@@ -437,7 +437,8 @@ class CFClient(object):
                     tmpfile.write(udata)
             with open(tmp, "rb") as tmpfile:
                 self.connection.put_object(cont.name, obj_name,
-                        contents=tmpfile, content_type=content_type, etag=etag)
+                        contents=tmpfile, content_type=content_type, etag=etag,
+                        headers=headers)
         return self.get_object(container, obj_name)
 
 
@@ -494,7 +495,7 @@ class CFClient(object):
 
     @handle_swiftclient_exception
     def upload_file(self, container, file_or_path, obj_name=None,
-            content_type=None, etag=None, return_none=False):
+            content_type=None, etag=None, return_none=False, headers=None):
         """
         Uploads the specified file to the container. If no name is supplied, the
         file's name will be used. Either a file path or an open file-like object
@@ -511,7 +512,7 @@ class CFClient(object):
             fileobj.seek(currpos)
             return total_size
 
-        def upload(fileobj, content_type, etag):
+        def upload(fileobj, content_type, etag, headers):
             if isinstance(fileobj, basestring):
                 # This is an empty directory file
                 fsize = 0
@@ -521,7 +522,7 @@ class CFClient(object):
                 # We can just upload it as-is.
                 return self.connection.put_object(cont.name, obj_name,
                         contents=fileobj, content_type=content_type,
-                        etag=etag)
+                        etag=etag, headers=headers)
             # Files larger than self.max_file_size must be segmented
             # and uploaded separately.
             num_segments = int(math.ceil(float(fsize) / self.max_file_size))
@@ -539,11 +540,12 @@ class CFClient(object):
                         etag = utils.get_checksum(tmp)
                         self.connection.put_object(cont.name, seg_name,
                                 contents=tmp, content_type=content_type,
-                                etag=etag)
+                                etag=etag, headers=headers)
             # Upload the manifest
-            hdr = {"X-Object-Meta-Manifest": "%s." % fname}
+            headers = headers or {}
+            headers["X-Object-Meta-Manifest"] = "%s." % fname
             return self.connection.put_object(cont.name, fname,
-                    contents=None, headers=hdr)
+                    contents=None, headers=headers)
 
         ispath = isinstance(file_or_path, basestring)
         if ispath:
@@ -560,9 +562,9 @@ class CFClient(object):
         if ispath and os.path.isfile(file_or_path):
             # Need to wrap the call in a context manager
             with open(file_or_path, "rb") as ff:
-                upload(ff, content_type, etag)
+                upload(ff, content_type, etag, headers)
         else:
-            upload(file_or_path, content_type, etag)
+            upload(file_or_path, content_type, etag, headers)
         if return_none:
             return None
         else:

--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -128,17 +128,18 @@ class Container(object):
         return [obj.name for obj in objs]
 
 
-    def store_object(self, obj_name, data, content_type=None, etag=None):
+    def store_object(self, obj_name, data, content_type=None, etag=None,
+            headers=None):
         """
         Creates a new object in this container, and populates it with
         the given data.
         """
         return self.client.store_object(self, obj_name, data,
-                content_type=content_type, etag=etag)
+                content_type=content_type, etag=etag, headers=headers)
 
 
     def upload_file(self, file_or_path, obj_name=None, content_type=None, etag=None,
-            return_none=False):
+            return_none=False, headers=None):
         """
         Uploads the specified file to this container. If no name is supplied, the
         file's name will be used. Either a file path or an open file-like object
@@ -146,7 +147,8 @@ class Container(object):
         returned, unless 'return_none' is set to True.
         """
         return self.client.upload_file(self, file_or_path, obj_name=obj_name,
-                content_type=content_type, etag=etag, return_none=return_none)
+                content_type=content_type, etag=etag, return_none=return_none,
+                headers=headers)
 
 
     def delete_object(self, obj):

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -323,7 +323,8 @@ class CF_ClientTest(unittest.TestCase):
         content = u"something with ü†ƒ-8"
         etag = utils.get_checksum(content)
         obj = client.store_object(self.cont_name, self.obj_name, content,
-                content_type="test/test", etag=etag)
+                content_type="test/test", etag=etag,
+                headers={"Content-Encoding": "gzip"})
         self.assertEqual(client.connection.put_object.call_count, 1)
         client.get_object = gobj
 

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -143,7 +143,8 @@ class CF_ContainerTest(unittest.TestCase):
         content = "something"
         etag = utils.get_checksum(content)
         obj = cont.store_object(self.obj_name, content,
-                content_type="test/test", etag=etag)
+                content_type="test/test", etag=etag,
+                headers={"Content-Encoding": "gzip"})
         self.assertEqual(cont.client.connection.put_object.call_count, 1)
         cont.client.get_object = gobj
 


### PR DESCRIPTION
Added to both the client and container versions of these functions. This is
primarily to add support for setting Content-Encoding: gzip to uploaded files.

See
http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_File_Compression_with_the_Content-Encoding_Header-d1e2198.html
