### PR TITLE
add content_encoding argument to upload_file and store_object

### DIFF
--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -107,7 +107,7 @@ class Container(object):
             name = name.decode(pyrax.get_encoding())
         ret = self._object_cache.get(name)
         if not ret:
-            objs = [obj for obj in self.client.get_container_objects(self.name)
+            objs = [obj for obj in self.client.get_container_objects(self.name, full_listing=True)
                     if obj.name == name]
             try:
                 ret = objs[0]
@@ -128,17 +128,19 @@ class Container(object):
         return [obj.name for obj in objs]
 
 
-    def store_object(self, obj_name, data, content_type=None, etag=None):
+    def store_object(self, obj_name, data, content_type=None, etag=None,
+            content_encoding=None):
         """
         Creates a new object in this container, and populates it with
         the given data.
         """
         return self.client.store_object(self, obj_name, data,
-                content_type=content_type, etag=etag)
+                content_type=content_type, etag=etag,
+                content_encoding=content_encoding)
 
 
     def upload_file(self, file_or_path, obj_name=None, content_type=None, etag=None,
-            return_none=False):
+            return_none=False, content_encoding=None):
         """
         Uploads the specified file to this container. If no name is supplied, the
         file's name will be used. Either a file path or an open file-like object
@@ -146,7 +148,8 @@ class Container(object):
         returned, unless 'return_none' is set to True.
         """
         return self.client.upload_file(self, file_or_path, obj_name=obj_name,
-                content_type=content_type, etag=etag, return_none=return_none)
+                content_type=content_type, etag=etag, return_none=return_none,
+                content_encoding=content_encoding)
 
 
     def delete_object(self, obj):

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -323,7 +323,8 @@ class CF_ClientTest(unittest.TestCase):
         content = u"something with ü†ƒ-8"
         etag = utils.get_checksum(content)
         obj = client.store_object(self.cont_name, self.obj_name, content,
-                content_type="test/test", etag=etag)
+                content_type="test/test", etag=etag,
+                content_encoding="gzip")
         self.assertEqual(client.connection.put_object.call_count, 1)
         client.get_object = gobj
 

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -143,7 +143,8 @@ class CF_ContainerTest(unittest.TestCase):
         content = "something"
         etag = utils.get_checksum(content)
         obj = cont.store_object(self.obj_name, content,
-                content_type="test/test", etag=etag)
+                content_type="test/test", etag=etag,
+                content_encoding="gzip")
         self.assertEqual(cont.client.connection.put_object.call_count, 1)
         cont.client.get_object = gobj
 


### PR DESCRIPTION
Added to both the client and container versions of these functions. This is to
add support for compressing objects before uploading them to cloudfiles.

See
http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_File_Compression_with_the_Content-Encoding_Header-d1e2198.html
