### PR TITLE
CloudDNSManager.get_record should probably return a CloudDNSRecord object

### DIFF
--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -784,9 +784,11 @@ class CloudDNSManager(BaseManager):
         Gets the full information for an existing record for this domain.
         """
         rec_id = utils.get_id(record)
-        uri = "/domains/%s/records/%s" % (utils.get_id(domain), rec_id)
-        resp, ret_body = self.api.method_get(uri)
-        return ret_body
+        domain_id = utils.get_id(domain)
+        uri = "/domains/%s/records/%s" % (domain_id, rec_id)
+        resp, record = self.api.method_get(uri)
+        record['domain_id'] = domain_id
+        return CloudDNSRecord(self, record, loaded=False)
 
 
     def update_record(self, domain, record, data=None, priority=None,


### PR DESCRIPTION
Currently CloudDNSManager.get_record returns a dict, it should probably return a CloudDNSRecord.

As it stands, if you get a record and then want to update it, you would have to do something like:

``` python
record = domain.get_record(record_id)
record_obj = pyrax.clouddns.CloudDNSRecord(pyrax.cloud_dns, record, loaded=False)
domain.update_record(record_obj, data=data)
```

This is due to CloudDNSManager.update_record looking for record.name which expects record to be a CloudDNSRecord instance.

This modification would allow something such as:

``` python
record = domain.get_record(record_id)
record.update(data=data)
```
