### PR TITLE
SSL Verification

### DIFF
--- a/docs/pyrax_doc.md
+++ b/docs/pyrax_doc.md
@@ -157,6 +157,7 @@ Setting | Affects | Default | Notes | Env. Variable
 **encoding** | The encoding to use when working with non-ASCII values. Unless you have a specific need, the default should work fine. | utf-8 | | CLOUD_ENCODING
 **custom_user_agent** | Customizes the User-agent string sent to the server. | -none- | | CLOUD_USER_AGENT
 **debug** | When True, causes all HTTP requests and responses to be output to the console to aid in debugging. | False | Previous versions called this setting 'http_debug'. | CLOUD_DEBUG
+**insecure** | When True, causes all HTTP requests to not perform SSL certificate verification. | False | | CLOUD_INSECURE
 
 Here is a sample:
 
@@ -169,6 +170,7 @@ Here is a sample:
     tenant_name = demo
     tenant_id = abc123456
     keyring_username = demo
+    insecure = True
 
     [public]
     identity_type = rackspace

--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -59,7 +59,7 @@ class BaseAuth(object):
 
 
     def __init__(self, username=None, password=None, token=None,
-            credential_file=None, region=None, timeout=None):
+            credential_file=None, region=None, timeout=None, insecure=False):
         self.username = username
         self.password = password
         self.token = token
@@ -68,6 +68,7 @@ class BaseAuth(object):
         self._timeout = timeout
         self.services = {}
         self.regions = set()
+        self.insecure = insecure
 
 
     @property
@@ -238,7 +239,11 @@ class BaseAuth(object):
             if data:
                 print "DATA", jdata
             print
-        return mthd(uri, data=jdata, headers=hdrs)
+        if self.insecure:
+            verify = False
+        else:
+            verify = True
+        return mthd(uri, data=jdata, headers=hdrs, verify=verify)
 
 
     def authenticate(self):

--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -86,7 +86,8 @@ class CFClient(object):
 
     def __init__(self, auth_endpoint, username, api_key=None, password=None,
             tenant_name=None, preauthurl=None, preauthtoken=None,
-            auth_version="2", os_options=None, http_log_debug=False):
+            auth_version="2", os_options=None, http_log_debug=False,
+            insecure=False):
         self.connection = None
         self.cdn_connection = None
         self.http_log_debug = http_log_debug
@@ -95,18 +96,20 @@ class CFClient(object):
         self._make_connections(auth_endpoint, username, api_key, password,
                 tenant_name=tenant_name, preauthurl=preauthurl,
                 preauthtoken=preauthtoken, auth_version=auth_version,
-                os_options=os_options, http_log_debug=http_log_debug)
+                os_options=os_options, http_log_debug=http_log_debug,
+                insecure=insecure)
 
 
     def _make_connections(self, auth_endpoint, username, api_key, password,
             tenant_name=None, preauthurl=None, preauthtoken=None,
-            auth_version="2", os_options=None, http_log_debug=None):
+            auth_version="2", os_options=None, http_log_debug=None,
+            insecure=False):
         cdn_url = os_options.pop("object_cdn_url", None)
         pw_key = api_key or password
         self.connection = Connection(auth_endpoint, username, pw_key,
                 tenant_name, preauthurl=preauthurl, preauthtoken=preauthtoken,
                 auth_version=auth_version, os_options=os_options,
-                http_log_debug=http_log_debug)
+                http_log_debug=http_log_debug, insecure=insecure)
         if cdn_url:
             self.connection._make_cdn_connection(cdn_url)
 

--- a/pyrax/client.py
+++ b/pyrax/client.py
@@ -48,7 +48,7 @@ class BaseClient(httplib2.Http):
 
     def __init__(self, region_name=None, endpoint_type="publicURL",
             management_url=None, service_type=None, service_name=None,
-            timings=False, http_log_debug=False, timeout=None):
+            timings=False, http_log_debug=False, timeout=None, insecure=False):
         super(BaseClient, self).__init__(timeout=timeout)
         self.version = "v1.1"
         self.region_name = region_name
@@ -62,6 +62,7 @@ class BaseClient(httplib2.Http):
 
         # httplib2 overrides
         self.force_exception_to_status_code = True
+        self.disable_ssl_certificate_validation = insecure
 
         self._logger = logging.getLogger(self.__class__.__name__)
         ch = logging.StreamHandler()

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -258,7 +258,7 @@ class IdentityTest(unittest.TestCase):
             ident.method_post(uri, data=data, headers=headers,
                     std_headers=std_headers)
             requests.post.assert_called_with(uri, data=jdata,
-                    headers=expected_headers)
+                    headers=expected_headers, verify=True)
         requests.post = sav_post
 
     def test_list_users(self):


### PR DESCRIPTION
novaclient has the ability to accept an insecure argument, to specify that SSL certificates should not be validated.

Unfortunately, the BaseAuth class has no way to specify that SSL certs should be ignored.  As a quick hack, I have monkey patched the _call method to add verify=False to the requests call.

BaseAuth, should probably take an argument to specify whether or not to validate SSL certificates.
