### PR TITLE
Fix returned results on args(not kwargs) passed into create

### DIFF
--- a/docs/cloud_databases.md
+++ b/docs/cloud_databases.md
@@ -82,7 +82,7 @@ There are two variations: calling the `create_database()` method of a `CloudData
 
 or:
 
-    db = cdb.create_instance(inst, "db_name")
+    db = cdb.create(inst, "db_name")
     print "DB:", db
 
 Both calls return an object representing the newly-created database:

--- a/pyrax/manager.py
+++ b/pyrax/manager.py
@@ -82,13 +82,15 @@ class BaseManager(object):
         return self._get(uri)
 
 
-    def create(self, name, return_none=False, return_raw=False,
-            return_response=False, *args, **kwargs):
+    def create(self, name, *args, **kwargs):
         """
         Subclasses need to implement the _create_body() method
         to return a dict that will be used for the API request
         body.
         """
+        return_none = kwargs.get("return_none", False)
+        return_raw = kwargs.get("return_raw", False)
+        return_response = kwargs.get("return_response", False)
         body = self.api._create_body(name, *args, **kwargs)
         return self._create("/%s" % self.uri_base, body,
                 return_none=return_none, return_raw=return_raw,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -110,8 +110,8 @@ class ClientTest(unittest.TestCase):
         mgr = self.client._manager
         sav = mgr.create
         mgr.create = Mock()
-        self.client.create("val")
-        mgr.create.assert_called_once_with("val")
+        self.client.create("val", 1, 1)
+        mgr.create.assert_called_once_with("val", 1, 1)
         mgr.create = sav
 
     def test_unauthenticate(self):


### PR DESCRIPTION
Was having issues when creating database instances and getting None returned back.  Appears that when calling create and not passing the arguments as kwargs, the second argument was being assigned to the return_none bool which was successfully creating the instance but not returning any info on it.  
