### PR TITLE
Add support for response_dict parameter to some swiftclient.client.Connection calls.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "python-novaclient>=2.13.0",
         "rackspace-novaclient",
-        "python-swiftclient",
+        "python-swiftclient>=1.5.0",
         "httplib2",
         "keyring",
     ] + testing_requires,

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -179,7 +179,7 @@ class CF_ContainerTest(unittest.TestCase):
         cont.client.connection.delete_object = Mock()
         cont.delete_object(self.obj_name)
         cont.client.connection.delete_object.assert_called_with(self.cont_name,
-                self.obj_name)
+                self.obj_name, response_dict=None)
 
     @patch('pyrax.cf_wrapper.client.Container', new=FakeContainer)
     def test_delete_all_objects(self):
@@ -191,14 +191,14 @@ class CF_ContainerTest(unittest.TestCase):
                 return_value=[self.obj_name])
         cont.delete_all_objects()
         cont.client.connection.delete_object.assert_called_with(
-                self.cont_name, self.obj_name)
+                self.cont_name, self.obj_name, response_dict=None)
 
     def test_delete(self):
         cont = self.container
         cont.client.connection.delete_container = Mock()
         cont.delete()
         cont.client.connection.delete_container.assert_called_with(
-                self.cont_name)
+                self.cont_name, response_dict=None)
 
     def test_fetch_object(self):
         cont = self.container
@@ -234,7 +234,7 @@ class CF_ContainerTest(unittest.TestCase):
         cont.client.connection.post_container = Mock()
         cont.set_metadata({"newkey": "newval"})
         cont.client.connection.post_container.assert_called_with(cont.name,
-                {"x-container-meta-newkey": "newval"})
+                {"x-container-meta-newkey": "newval"}, response_dict=None)
 
     def test_set_web_index_page(self):
         cont = self.container
@@ -242,7 +242,7 @@ class CF_ContainerTest(unittest.TestCase):
         cont.client.connection.post_container = Mock()
         cont.set_web_index_page(page)
         cont.client.connection.post_container.assert_called_with(cont.name,
-                {"x-container-meta-web-index": page})
+                {"x-container-meta-web-index": page}, response_dict=None)
 
     def test_set_web_error_page(self):
         cont = self.container
@@ -250,7 +250,7 @@ class CF_ContainerTest(unittest.TestCase):
         cont.client.connection.post_container = Mock()
         cont.set_web_error_page(page)
         cont.client.connection.post_container.assert_called_with(cont.name,
-                {"x-container-meta-web-error": page})
+                {"x-container-meta-web-error": page}, response_dict=None)
 
     def test_make_public(self, ttl=None):
         cont = self.container
@@ -303,7 +303,8 @@ class CF_ContainerTest(unittest.TestCase):
         obj_name = utils.random_name()
         cont.delete_object_in_seconds(obj_name, seconds=secs)
         cont.client.connection.post_object.assert_called_with(cont.name,
-                obj_name, headers={'X-Delete-After': secs})
+                obj_name, headers={'X-Delete-After': secs},
+                response_dict=None)
 
         nm = utils.random_name(ascii_only=True)
         sav = cont.name

--- a/tests/unit/test_cf_storage_object.py
+++ b/tests/unit/test_cf_storage_object.py
@@ -144,7 +144,7 @@ class CF_StorageObjectTest(unittest.TestCase):
         obj.client.connection.delete_object = Mock()
         obj.delete()
         obj.client.connection.delete_object.assert_called_with(
-                obj.container.name, obj.name)
+                obj.container.name, obj.name, response_dict=None)
 
     def test_purge(self):
         obj = self.storage_object
@@ -172,7 +172,8 @@ class CF_StorageObjectTest(unittest.TestCase):
         obj.client.connection.head_object = Mock(return_value={})
         obj.set_metadata({"newkey": "newval"})
         obj.client.connection.post_object.assert_called_with(obj.container.name,
-                obj.name, {"x-object-meta-newkey": "newval"})
+                obj.name, {"x-object-meta-newkey": "newval"},
+                response_dict=None)
 
     def test_remove_metadata_key(self):
         obj = self.storage_object
@@ -180,7 +181,7 @@ class CF_StorageObjectTest(unittest.TestCase):
         obj.client.connection.head_object = Mock(return_value={})
         obj.remove_metadata_key("newkey")
         obj.client.connection.post_object.assert_called_with(obj.container.name,
-                obj.name, {})
+                obj.name, {}, response_dict=None)
 
     def test_change_content_type(self):
         obj = self.storage_object
@@ -203,7 +204,8 @@ class CF_StorageObjectTest(unittest.TestCase):
         secs = random.randint(1, 1000)
         obj.delete_in_seconds(seconds=secs)
         obj.client.connection.post_object.assert_called_with(obj.container.name,
-                obj.name, headers={'X-Delete-After': secs})
+                obj.name, headers={'X-Delete-After': secs},
+                response_dict=None)
 
     def test_repr(self):
         obj = self.storage_object


### PR DESCRIPTION
swiftclient was [changed in 1.5.0](https://github.com/openstack/python-swiftclient/commit/3f66a8ae6b8d9741809773a9665d4768d2f161a6) to add an optional `response_dict` parameter to several `swiftclient.client.Connection` methods, which allows for status, reason, and header information to be given back to callers. The `pyrax.cf_wrapper.client.CFClient` methods which call into those swiftclient methods were given an optional `extra_info` parameter which is passed on.

This fixes #126.
