### PR TITLE
Allow BaseAuth to support disabling of ssl verification

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -214,6 +214,10 @@ class Settings(object):
             if "LON" in (current, val):
                 # This is an outlier, as it has a separate auth
                 identity.region = val
+        elif key == "verify_ssl":
+            if not identity:
+                return
+            identity.verify_ssl = val
 
 
     def _getEnvironment(self):
@@ -351,7 +355,8 @@ def _create_identity():
     if not cls:
         raise exc.IdentityClassNotDefined("No identity class has "
                 "been defined for the current environment.")
-    identity = cls()
+    verify_ssl = get_setting("verify_ssl")
+    identity = cls(verify_ssl=verify_ssl)
 
 
 def _assure_identity(fnc):

--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -59,7 +59,7 @@ class BaseAuth(object):
 
 
     def __init__(self, username=None, password=None, token=None,
-            credential_file=None, region=None, timeout=None):
+            credential_file=None, region=None, timeout=None, verify_ssl=True):
         self.username = username
         self.password = password
         self.token = token
@@ -68,6 +68,7 @@ class BaseAuth(object):
         self._timeout = timeout
         self.services = {}
         self.regions = set()
+        self.verify_ssl = verify_ssl
 
 
     @property
@@ -243,7 +244,7 @@ class BaseAuth(object):
             if data:
                 print "DATA", jdata
             print
-        return mthd(uri, data=jdata, headers=hdrs)
+        return mthd(uri, data=jdata, headers=hdrs, verify=self.verify_ssl)
 
 
     def authenticate(self):

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -361,7 +361,7 @@ class IdentityTest(unittest.TestCase):
                 ident.method_post(uri, data=data, headers=headers,
                         std_headers=std_headers, admin=admin)
                 requests.post.assert_called_with(uri, data=jdata,
-                        headers=expected_headers)
+                        headers=expected_headers, verify=True)
                 self.assertTrue(out.getvalue())
                 out.seek(0)
                 out.truncate()


### PR DESCRIPTION
The work in #96 added the ability to disable ssl verification, but it looks like BaseAuth was missed, causing SSL verification to potentially fail with verify_ssl set to False when authenticating.
