### PR TITLE
upload_file: Can now specify content_length

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -606,7 +606,8 @@ class CFClient(object):
     @handle_swiftclient_exception
     def upload_file(self, container, file_or_path, obj_name=None,
             content_type=None, etag=None, return_none=False,
-            content_encoding=None, ttl=None, extra_info=None):
+            content_encoding=None, ttl=None, extra_info=None,
+            content_length=None):
         """
         Uploads the specified file to the container. If no name is supplied,
         the file's name will be used. Either a file path or an open file-like
@@ -616,6 +617,8 @@ class CFClient(object):
         You may optionally set the `content_type` and `content_encoding`
         parameters; pyrax will create the appropriate headers when the object
         is stored.
+
+        If the size of the file is known, it can be passed as `content_length`.
 
         If you wish for the object to be temporary, specify the time it should
         be stored in seconds in the `ttl` parameter. If this is specified, the
@@ -637,7 +640,10 @@ class CFClient(object):
                 # This is an empty directory file
                 fsize = 0
             else:
-                fsize = get_file_size(fileobj)
+                if content_length is None:
+                    fsize = get_file_size(fileobj)
+                else:
+                    fsize = content_length
             if fsize < self.max_file_size:
                 # We can just upload it as-is.
                 return self.connection.put_object(cont.name, obj_name,

--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -143,7 +143,8 @@ class Container(object):
 
 
     def upload_file(self, file_or_path, obj_name=None, content_type=None,
-            etag=None, return_none=False, content_encoding=None, ttl=None):
+            etag=None, return_none=False, content_encoding=None, ttl=None,
+            content_length=None):
         """
         Uploads the specified file to this container. If no name is supplied,
         the file's name will be used. Either a file path or an open file-like
@@ -152,7 +153,8 @@ class Container(object):
         """
         return self.client.upload_file(self, file_or_path, obj_name=obj_name,
                 content_type=content_type, etag=etag, return_none=return_none,
-                content_encoding=content_encoding, ttl=None)
+                content_encoding=content_encoding, ttl=None,
+                content_length=content_length)
 
 
     def delete_object(self, obj):


### PR DESCRIPTION
The caller can now specify content_length for the file-like object, if
known. Doing so avoids the call to get_file_size(), which would not work
if the file is not seekable.

The result is that a file can be uploaded from a portion of a streamed
HTTP request.
