### PR TITLE
Fixes the download method on CF object

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -948,7 +948,8 @@ class CFClient(object):
         path, fname = os.path.split(obj_name)
         if structure:
             fullpath = os.path.join(directory, path)
-            os.makedirs(fullpath)
+            if (os.path.isdir(fullpath)):
+                os.makedirs(fullpath)
             target = os.path.join(fullpath, fname)
         else:
             target = os.path.join(directory, fname)

--- a/pyrax/cf_wrapper/storage_object.py
+++ b/pyrax/cf_wrapper/storage_object.py
@@ -88,7 +88,7 @@ class StorageObject(object):
         directory by default. If you do not want the nested folders to be
         created, pass `structure=False` in the parameters.
         """
-        return self.client.download_object(self.container, self, directory,
+        return self.client.download_object(self.container, self.name, directory,
                 structure=structure)
 
 

--- a/tests/unit/test_cf_storage_object.py
+++ b/tests/unit/test_cf_storage_object.py
@@ -136,7 +136,7 @@ class CF_StorageObjectTest(unittest.TestCase):
         dname = utils.random_name()
         stru = random.choice((True, False))
         obj.download(dname, structure=stru)
-        obj.client.download_object.assert_called_once_with(obj.container, obj,
+        obj.client.download_object.assert_called_once_with(obj.container, obj.name,
                 dname, structure=stru)
 
     def test_delete(self):


### PR DESCRIPTION
The download_object function in client.py expects an object name to be passed while the download method in storage_object.py passes an obj. Also, it is trying to download the file to an existing directory, the download blows up. This pull request also fixes that issue.
