### PR TITLE
Fixes #166. Add raw=True when parsing passwords.

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -180,7 +180,7 @@ class BaseAuth(object):
         Implements the default (keystone) behavior.
         """
         self.username = cfg.get("keystone", "username")
-        self.password = cfg.get("keystone", "password")
+        self.password = cfg.get("keystone", "password", raw=True)
         self.tenant_id = cfg.get("keystone", "tenant_id")
 
 

--- a/pyrax/identity/rax_identity.py
+++ b/pyrax/identity/rax_identity.py
@@ -27,10 +27,10 @@ class RaxIdentity(BaseAuth):
     def _read_credential_file(self, cfg):
         self.username = cfg.get("rackspace_cloud", "username")
         try:
-            self.password = cfg.get("rackspace_cloud", "api_key")
+            self.password = cfg.get("rackspace_cloud", "api_key", raw=True)
         except ConfigParser.NoOptionError as e:
             # Allow either the use of either 'api_key' or 'password'.
-            self.password = cfg.get("rackspace_cloud", "password")
+            self.password = cfg.get("rackspace_cloud", "password", raw=True)
 
 
     def _get_credentials(self):

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -173,7 +173,8 @@ class IdentityTest(unittest.TestCase):
     def test_set_credential_file(self):
         ident = self.rax_identity_class()
         user = "fakeuser"
-        key = "fakeapikey"
+        # Use percent signs in key to ensure it doesn't get interpolated.
+        key = "fake%api%key"
         ident.authenticate = Mock()
         with utils.SelfDeletingTempfile() as tmpname:
             with open(tmpname, "wb") as ff:


### PR DESCRIPTION
When parsing .pyrax, we should set the raw=True argument on ConfigParser.SafeConfigParser.get on key or password fields, allowing percent signs to be used there. Without this, users get InterpolationSyntaxError. Switching from SafeConfigParser to RawConfigParser would do the same thing, but it's backwards incompatible because we could have people relying on interpolation elsewhere in their config files.
