### PR TITLE
Add identity_type configuration to Cloud Monitoring samples

### DIFF
--- a/samples/cloud_monitoring/create_alarm.py
+++ b/samples/cloud_monitoring/create_alarm.py
@@ -25,6 +25,7 @@ import pyrax
 
 from util import option_chooser
 
+pyrax.set_setting("identity_type", "rackspace")
 creds_file = os.path.expanduser("~/.rackspace_cloud_credentials")
 pyrax.set_credential_file(creds_file)
 cm = pyrax.cloud_monitoring

--- a/samples/cloud_monitoring/create_check.py
+++ b/samples/cloud_monitoring/create_check.py
@@ -25,6 +25,7 @@ import pyrax
 
 from util import option_chooser
 
+pyrax.set_setting("identity_type", "rackspace")
 creds_file = os.path.expanduser("~/.rackspace_cloud_credentials")
 pyrax.set_credential_file(creds_file)
 cm = pyrax.cloud_monitoring

--- a/samples/cloud_monitoring/create_entity.py
+++ b/samples/cloud_monitoring/create_entity.py
@@ -21,6 +21,7 @@ import sys
 
 import pyrax
 
+pyrax.set_setting("identity_type", "rackspace")
 creds_file = os.path.expanduser("~/.rackspace_cloud_credentials")
 pyrax.set_credential_file(creds_file)
 cm = pyrax.cloud_monitoring

--- a/samples/cloud_monitoring/create_notification.py
+++ b/samples/cloud_monitoring/create_notification.py
@@ -25,6 +25,7 @@ import pyrax
 
 from util import option_chooser
 
+pyrax.set_setting("identity_type", "rackspace")
 creds_file = os.path.expanduser("~/.rackspace_cloud_credentials")
 pyrax.set_credential_file(creds_file)
 cm = pyrax.cloud_monitoring


### PR DESCRIPTION
As with other samples, the CM samples need to have the identity_type configuration option set to "rackspace"
