### PR TITLE
Add support for accepting UNIX timestamps to get_metric_data_points

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -484,6 +484,7 @@ class CloudMonitorEntityManager(BaseManager):
         start_tm = utils.to_timestamp(start)
         end_tm = utils.to_timestamp(end)
         qparms = []
+        # Timestamps with fractional seconds currently cause a 408 (timeout)
         qparms.append("from=%s" % int(start_tm))
         qparms.append("to=%s" % int(end_tm))
         if points:

--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -4,6 +4,7 @@
 import datetime
 import fnmatch
 import hashlib
+from numbers import Number
 import os
 import random
 import re
@@ -416,7 +417,10 @@ def to_timestamp(val):
     representation of a date/datetime value. Returns a standard Unix timestamp
     corresponding to that value.
     """
-    if isinstance(val, basestring):
+    # If we're given a number, give it right back - it's already a timestamp.
+    if isinstance(val, Number):
+        return val
+    elif isinstance(val, basestring):
         dt = _parse_datetime_string(val)
     else:
         dt = val


### PR DESCRIPTION
`cloud_monitoring.get_metric_data_points` operates on a start and end timestamp, but previously the function was unable to directly receive a UNIX timestamp value, only Python date/datetime or string-based timestamps. `utils.to_timestamp` now returns numbers given to it, as they're already timestamps. This change makes it work as the docstring suggests.

Also added a comment to `get_metric_data_points` to explain the existing conversion of UNIX timestamps to integers. The API currently times out when given timestamps with fractional seconds.
