### PR TITLE
Added bits to make building an RPM possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+build/
+dist/
+rpm-build/
+rpms/
 *~
 .DS_Store
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+PACKAGE := $(shell basename *.spec .spec)
+ARCH = noarch
+RPMBUILD = rpmbuild --define "_topdir %(pwd)/rpm-build" \
+	--define "_builddir %{_topdir}" \
+	--define "_rpmdir %(pwd)/rpms" \
+	--define "_srcrpmdir %{_rpmdir}" \
+	--define "_sourcedir  %{_topdir}"
+PYTHON = $(which python)
+
+all: rpms
+
+clean:
+	rm -rf dist/ build/ rpm-build/ rpms/
+	rm -rf docs/*.gz MANIFEST *~
+	find . -name '*.pyc' -exec rm -f {} \;
+
+build: clean
+	python setup.py build -f
+
+install: build
+	python setup.py install -f
+
+reinstall: uninstall install
+
+uninstall: clean
+	rm -f /usr/bin/${PACKAGE}
+	rm -rf /usr/lib/python2.*/site-packages/${PACKAGE}
+
+uninstall_rpms: clean
+	rpm -e ${PACKAGE}
+
+sdist:
+	python setup.py sdist
+
+prep_rpmbuild: build sdist
+	mkdir -p rpm-build
+	mkdir -p rpms
+	cp dist/*.gz rpm-build/
+
+rpms: prep_rpmbuild
+	${RPMBUILD} -ba ${PACKAGE}.spec
+
+srpm: prep_rpmbuild
+	${RPMBUILD} -bs ${PACKAGE}.spec

--- a/pyrax.spec
+++ b/pyrax.spec
@@ -1,0 +1,56 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+Name:           pyrax
+Version:        1.5.0
+Release:        1%{?dist}
+Summary:        Python language bindings for OpenStack Clouds
+
+License:        ASLv2
+URL:            https://github.com/rackerlabs/pyrax
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  python-setuptools
+BuildRequires:  python-mock
+Requires:       python-novaclient >= 2.13.0
+Requires:       python-swiftclient >= 1.5.0
+Requires:       python-httplib2
+Requires:       python-keyring
+
+
+%description
+A library for working with most OpenStack-based cloud deployments, though it
+originally targeted the Rackspace public cloud. For example, the code for
+cloudfiles contains the ability to publish your content on Rackspace's CDN
+network, even though CDN support is not part of OpenStack Swift. But if you
+don't use any of the CDN-related code, your app will work fine on any
+standard Swift deployment.
+
+
+%package rackspace
+Summary:        Bring in the bits that work with Rackspace's Cloud
+Requires:       pyrax
+Requires:       rackspace-novaclient
+
+%description rackspace
+The Rackspace Cloud has additional libraries that are required to access
+all the things.  This package just makes sure they are available for pyrax.
+
+%prep
+%setup -q
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%{__python} setup.py install --root $RPM_BUILD_ROOT
+
+%files
+%{python_sitelib}/*
+#%{_bindir}/
+
+%changelog
+* Fri Sep 6 2013 Greg Swift <gregswift@gmail.com> - 1.5.0-1
+- Initial spec

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+optimize = 1


### PR DESCRIPTION
The spec file is the framework for the RPM, and setup.cfg is for good handling of .py[oc] files by RPM.
The Make file facilitates local building of the RPM and can be extended to support other package types.
Then updates to the .gitignore so no one accidentally checks in build artifacts
