### PR TITLE
Hande 400 errors in pyrax.identity.create_user

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -479,6 +479,13 @@ class BaseAuth(object):
                     "users.")
         elif resp.status_code == 409:
             raise exc.DuplicateUser("User '%s' already exists." % name)
+        elif resp.status_code == 400:
+            status = json.loads(resp.text)
+            message = status["badRequest"]["message"]
+            if "Expecting valid email address" in message:
+                raise exc.InvalidEmail("%s is not valid" % email)
+            else:
+                raise exc.BadRequest(message)
 
 
     # Can we really update the ID? Docs seem to say we can

--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -89,6 +89,9 @@ class FileNotFound(PyraxException):
 class FolderNotFound(PyraxException):
     pass
 
+class InvalidEmail(PyraxException):
+    pass
+
 class KeyringModuleNotInstalled(PyraxException):
     pass
 

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -526,6 +526,21 @@ class IdentityTest(unittest.TestCase):
             self.assertRaises(exc.AuthorizationFailure, ident.create_user,
                     fake_name, fake_email, fake_password)
 
+    def test_create_user_bad_email(self):
+        for cls in self.id_classes.values():
+            ident = cls()
+            resp = fakes.FakeIdentityResponse()
+            resp.response_type = "users"
+            resp.status_code = 400
+            resp.text = json.dumps(
+                {"badRequest": {"message": "Expecting valid email address"}})
+            ident.method_post = Mock(return_value=resp)
+            fake_name = utils.random_name()
+            fake_email = utils.random_name()
+            fake_password = utils.random_name()
+            self.assertRaises(exc.InvalidEmail, ident.create_user,
+                    fake_name, fake_email, fake_password)
+
     def test_create_user_not_found(self):
         for cls in self.id_classes.values():
             ident = cls()


### PR DESCRIPTION
Previously, 400 errors were being silently ignored, so `pyrax.identity.create_user("name", "invalidemail")` would return None. In reality, this was getting an HTTP 400 error with a message about an invalid email address being passed in. We now check if the HTTP message includes text about invalid email, then raise `pyrax.exceptions.InvalidEmail` if so, otherwise raise a generic `pyrax.exceptions.BadRequest`.

This fixes #168.
