### PR TITLE
Moved get_limits into base client

### DIFF
--- a/pyrax/client.py
+++ b/pyrax/client.py
@@ -140,6 +140,14 @@ class BaseClient(httplib2.Http):
         self.times = []
 
 
+    def get_limits(self):
+        """
+        Returns a dict with the resource and rate limits for the account.
+        """
+        resp, resp_body = self.method_get("/limits")
+        return resp_body
+
+
     def http_log_req(self, args, kwargs):
         """
         When self.http_log_debug is True, outputs the equivalent `curl`

--- a/pyrax/clouddatabases.py
+++ b/pyrax/clouddatabases.py
@@ -606,6 +606,11 @@ class CloudDatabaseClient(BaseClient):
         return instance.resize(flavor)
 
 
+    def get_limits(self):
+        """Overridden as Cloud Databases limits are hard coded."""
+        pass
+
+
     def list_flavors(self):
         """Returns a list of all available Flavors."""
         return self._flavor_manager.list()

--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -850,14 +850,6 @@ class CloudMonitorClient(BaseClient):
         return resp_body
 
 
-    def get_limits(self):
-        """
-        Returns a dict with the resource and rate limits for the account.
-        """
-        resp, resp_body = self.method_get("/limits")
-        return resp_body
-
-
     def get_audits(self):
         """
         Every write operation performed against the API (PUT, POST or DELETE)


### PR DESCRIPTION
Cloud databases doesn't implement /limits so its overridden in the client.  
