### PR TITLE
[autoscale] Implement new "replace" methods

### DIFF
--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -402,6 +402,7 @@ class AutoscaleTest(unittest.TestCase):
             "cooldown": new_cooldown,
             "minEntities": new_min,
             "maxEntities": new_max,
+            "metadata": {}
         }
         mgr.replace(sg.id, new_name, new_cooldown, new_min, new_max)
         mgr.api.method_put.assert_called_once_with(uri, body=expected_body)
@@ -871,7 +872,7 @@ class AutoscaleTest(unittest.TestCase):
         mgr.api.method_put = Mock(return_value=(None, None))
         uri = "/%s/%s/policies/%s/webhooks/%s" % (mgr.uri_base, sg.id, pol.id,
                 hook)
-        expected = {"name": new_name}
+        expected = {"name": new_name, "metadata": {}}
         ret = mgr.replace_webhook(sg, pol, hook, name=new_name)
         mgr.api.method_put.assert_called_with(uri, body=expected)
 


### PR DESCRIPTION
This branch introduces the following methods on the autoscale client and manager objects:

replace - replaces all data in a group config
replace_launch_config - replaces all data in a launch config
replace_policy - replaces all data in a scaling policy
replace_webhook - replaces all data in a webhook

These are necessary because the update\* methods don't have a way to completely replace all properties -- specifically, if there's an optional property, the update methods have no way to DELETE that property.

The use of RSAS in Heat involves maintaining the desired state of all the autoscale objects externally (in the Heat template) and updating (replacing) them entirely when anything changes, so these methods will make that possible.

Additionally I fixed the update_launch_config handling of "key_name" and update_policy handling of "args" to match the existing behavior -- when I originally implemented them I did not make them take the value from the existing object.

I'm open to alternative designs, but right now I don't think there's any way in pyrax for me to do this.
