### PR TITLE
[loadbalancer] Cloud Load balancers no longer require nodes

### DIFF
--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -471,11 +471,10 @@ class CloudLoadBalancerManager(BaseManager):
         """
         Used to create the dict required to create a load balancer instance.
         """
-        required = (nodes, virtual_ips, port, protocol)
+        required = (virtual_ips, port, protocol)
         if not all(required):
             raise exc.MissingLoadBalancerParameters("Load Balancer creation "
-                    "requires at least one node, one virtual IP, "
-                    "a protocol, and a port.")
+                "requires at least one virtual IP, a protocol, and a port.")
         nodes = utils.coerce_string_to_list(nodes)
         virtual_ips = utils.coerce_string_to_list(virtual_ips)
         bad_conditions = [node.condition for node in nodes


### PR DESCRIPTION
Cloud Load Balancer used to have a limitation in that it wouldn't allow creation of LBs without any nodes. This restriction has been lifted in order to better support the use of autoscaling systems.

I've tested this in practice in the context of heat - I created a load balancer in a heat template and hooked it up to an autoscale launch configuration.
