### PR TITLE
Fix #231: upload_file() fails when file_or_path is open file larger than 5GB and obj_name is specified

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -769,7 +769,7 @@ class CFClient(object):
             # async design.
             for segment in xrange(num_segments):
                 sequence = str(segment + 1).zfill(digits)
-                seg_name = "%s.%s" % (fname, sequence)
+                seg_name = "%s.%s" % (obj_name, sequence)
                 with utils.SelfDeletingTempfile() as tmpname:
                     with open(tmpname, "wb") as tmp:
                         tmp.write(fileobj.read(self.max_file_size))
@@ -781,8 +781,8 @@ class CFClient(object):
                                 etag=etag, headers=headers,
                                 response_dict=extra_info)
             # Upload the manifest
-            headers["X-Object-Meta-Manifest"] = "%s." % fname
-            return self.connection.put_object(cont.name, fname,
+            headers["X-Object-Meta-Manifest"] = "%s." % obj_name
+            return self.connection.put_object(cont.name, obj_name,
                     contents=None, headers=headers,
                     response_dict=extra_info)
 


### PR DESCRIPTION
The file name (`fname`) was being used as the object name passed to put_object, instead of the object name, `obj_name`. This caused 2 problems:
1) the object name of the uploaded file was not the one the caller asked for
2) the get_object() call at the end of the method failed because it was (correctly) using `obj_name` as the name of the object to get.
