### PR TITLE
Add pinned dependency for pbr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 2",
     ],
     install_requires=[
+        "pbr==0.5.21",
         "python-novaclient>=2.13.0",
         "rackspace-novaclient",
         "python-swiftclient>=1.5.0",


### PR DESCRIPTION
Pin dependency for pbr to workaround [current issue with pbr](https://bugs.launchpad.net/ubuntu/+source/python-pbr/+bug/1245676).
