### PR TITLE
Initialise Container cdn data to defaults if no cdn_connection.

### DIFF
--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -35,12 +35,15 @@ class Container(object):
         self.name = name
         self.object_count = int(object_count)
         self.total_bytes = int(total_bytes)
-        self._cdn_uri = FAULT
-        self._cdn_ttl = FAULT
-        self._cdn_ssl_uri = FAULT
-        self._cdn_streaming_uri = FAULT
-        self._cdn_ios_uri = FAULT
-        self._cdn_log_retention = FAULT
+        if client.cdn_connection is not None:
+            self._cdn_uri = FAULT
+            self._cdn_ttl = FAULT
+            self._cdn_ssl_uri = FAULT
+            self._cdn_streaming_uri = FAULT
+            self._cdn_ios_uri = FAULT
+            self._cdn_log_retention = FAULT
+        else:
+            self._set_cdn_defaults()
         self._object_cache = {}
 
 


### PR DESCRIPTION
AFAICT, currently the Container.cdn_enabled property [errors when your client doesn't have a cdn connection](http://paste.ubuntu.com/6478049/) (ie. using non-rackspace openstack).

This branch ensures that when a Container object is initialised with a client, it sets the default cdn details if the client doesn't have a cdn connection, otherwise the previous behaviour of setting the values to be loaded lazily.
## Notes

I initially thought the Client.cdn_enabled class property was relevant, but then found it's never actually referenced anywhere, and the tests pass without it. So either there's code out there depending on a class property that always returns False, or it's not used at all. I'm assuming it should be removed, but didn't make that call given that it's a public property.

I added some whitespace to the 2 relevant tests only because it wasn't obvious (to me) where the test-setup, code execution and expectations started/ended. If that's not OK, happy to remove it.
