### PR TITLE
Use X-Object-Manifest instead of X-Object-Meta-Manifest when creating DLO

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -781,7 +781,7 @@ class CFClient(object):
                                 etag=etag, headers=headers,
                                 response_dict=extra_info)
             # Upload the manifest
-            headers["X-Object-Meta-Manifest"] = "%s." % obj_name
+            headers["X-Object-Manifest"] = "%s." % obj_name
             return self.connection.put_object(cont.name, obj_name,
                     contents=None, headers=headers,
                     response_dict=extra_info)

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -609,7 +609,7 @@ class CF_ClientTest(unittest.TestCase):
             self.assertEqual(put_calls[0][1][1], '%s.1' % obj_name)
             self.assertEqual(put_calls[1][1][1], '%s.2' % obj_name)
             self.assertEqual(put_calls[2][1][1], obj_name)
-            self.assertEqual(put_calls[2][2]["headers"]["X-Object-Meta-Manifest"],
+            self.assertEqual(put_calls[2][2]["headers"]["X-Object-Manifest"],
                              obj_name + ".")
 
             # get_object() should be called with the same name that was passed


### PR DESCRIPTION
This fixes 0-byte content when GETting Dynamic Large Objects (multipart files) created by pyrax from Rackspace Cloud Files (#258).
