### PR TITLE
Add requests as installation requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "python-swiftclient>=1.5.0",
         "httplib2",
         "keyring",
+        "requests>=1.0.0",
     ] + testing_requires,
     packages=[
         "pyrax",


### PR DESCRIPTION
requests is imported in [`base_identity.py`](https://github.com/rackspace/pyrax/blob/master/pyrax/base_identity.py#L8) but not required or documented for installation.

Additionally there were some made to requests's responses around the time of 1.0.0. So if you find that you've got a project with an older version of requests and try to authenticate using the 'rackspace' authentication scheme:

```
File "/usr/local/venv/myenv/local/lib/python2.7/site-packages/pyrax/__init__.py" in _auth_and_connect
  496.         identity.authenticate()
File "/usr/local/venv/myenv/local/lib/python2.7/site-packages/pyrax/identity/rax_identity.py" in authenticate
  63.             super(RaxIdentity, self).authenticate()
File "/usr/local/venv/myenv/local/lib/python2.7/site-packages/pyrax/base_identity.py" in authenticate
  293.         resp_body = resp.json()

Exception Type: TypeError at /dashboard/business/24011/
Exception Value: 'dict' object is not callable
```

In earlier versions of requests `json` was a dictionary. Updating requests solved this problem, but took some digging. It's simple to avoid by requiring a minimum version of the dependency. 

If it isn't suitable to require this dependency it would be good to document it somewhere.

Dupe of #268 which was made against the wrong branch.
