### PR TITLE
Files that are exactly the chunk size can be uploaded as is

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -756,7 +756,7 @@ class CFClient(object):
                     fsize = get_file_size(fileobj)
                 else:
                     fsize = content_length
-            if fsize < self.max_file_size:
+            if fsize <= self.max_file_size:
                 # We can just upload it as-is.
                 return self.connection.put_object(cont.name, obj_name,
                         contents=fileobj, content_type=content_type,


### PR DESCRIPTION
Due to https://github.com/rackspace/pyrax/issues/266, I wrote some code which uploads files that are exactly 5 GB - 1 bytes.  pyrax incorrectly uploads such files as a single chunk with a manifest, instead of as a normal file.
