### PR TITLE
Adding node id to cloud load balancer's Node's to_dict method

### DIFF
--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -1088,6 +1088,7 @@ class Node(object):
                 "port": self.port,
                 "condition": self.condition,
                 "type": self.type,
+                "id": self.id,
                 }
 
 

--- a/tests/unit/test_cloud_loadbalancers.py
+++ b/tests/unit/test_cloud_loadbalancers.py
@@ -1093,7 +1093,9 @@ class CloudLoadBalancerTest(unittest.TestCase):
         expected = {"address": nd.address,
                 "port": nd.port,
                 "condition": nd.condition,
-                "type": nd.type}
+                "type": nd.type,
+                "id": nd.id,
+                }
         self.assertEqual(nd.to_dict(), expected)
 
     def test_node_delete(self):


### PR DESCRIPTION
Add a Cloud Load Balancer's Node's id to the to_dict method, for use by applications consuming it (e.g. Ansible's rax_clb module: https://github.com/ansible/ansible/blob/devel/library/cloud/rax_clb).

Also adjusting the formatting in the unit test, so future additions will be one-liners in the diff.

More detail:
Ansible's rax_clb_nodes module currently requires node_id in order to work with nodes assigned to a load balancer. However when the rax_clb module invokes pyrax to list existing nodes, node_id is not returned in the response.

While rax_clb will be adding the ability to match IPs directly, including node_id in the pyrax Cloud Load Balancer "Node" dict might be a good idea in general.
