### PR TITLE
Added httpsRedirect param for load balancer 

### DIFF
--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -99,7 +99,7 @@ class CloudLoadBalancer(BaseResource):
 
 
     def update(self, name=None, algorithm=None, protocol=None, halfClosed=None,
-            port=None, timeout=None):
+            port=None, timeout=None, httpsRedirect=None):
         """
         Provides a way to modify the following attributes of a load balancer:
             - name
@@ -108,10 +108,11 @@ class CloudLoadBalancer(BaseResource):
             - halfClosed
             - port
             - timeout
+            - httpsRedirect
         """
         return self.manager.update(self, name=name, algorithm=algorithm,
                 protocol=protocol, halfClosed=halfClosed, port=port,
-                timeout=timeout)
+                timeout=timeout, httpsRedirect=httpsRedirect)
 
 
     def delete_node(self, node):
@@ -423,7 +424,7 @@ class CloudLoadBalancer(BaseResource):
 
 class CloudLoadBalancerManager(BaseManager):
     def update(self, lb, name=None, algorithm=None, protocol=None,
-            halfClosed=None, port=None, timeout=None):
+            halfClosed=None, port=None, timeout=None, httpsRedirect=None):
         """
         Provides a way to modify the following attributes of a load balancer:
             - name
@@ -432,6 +433,7 @@ class CloudLoadBalancerManager(BaseManager):
             - halfClosed
             - port
             - timeout
+            - httpsRedirect
         """
         body = {}
         if name is not None:
@@ -446,6 +448,8 @@ class CloudLoadBalancerManager(BaseManager):
             body["port"] = port
         if timeout is not None:
             body["timeout"] = timeout
+        if httpsRedirect is not None:
+            body["httpsRedirect"] = httpsRedirect
         if not body:
             # Nothing passed
             return
@@ -467,7 +471,8 @@ class CloudLoadBalancerManager(BaseManager):
     def _create_body(self, name, port=None, protocol=None, nodes=None,
             virtual_ips=None, algorithm=None, halfClosed=None, accessList=None,
             connectionLogging=None, connectionThrottle=None, healthMonitor=None,
-            metadata=None, timeout=None, sessionPersistence=None):
+            metadata=None, timeout=None, sessionPersistence=None,
+            httpsRedirect=None):
         """
         Used to create the dict required to create a load balancer instance.
         """
@@ -501,6 +506,7 @@ class CloudLoadBalancerManager(BaseManager):
                 "metadata": metadata,
                 "timeout": timeout,
                 "sessionPersistence": sessionPersistence,
+                "httpsRedirect": httpsRedirect,
                 }}
         return body
 
@@ -1296,7 +1302,7 @@ class CloudLoadBalancerClient(BaseClient):
 
     @assure_loadbalancer
     def update(self, loadbalancer, name=None, algorithm=None, protocol=None,
-            halfClosed=None, port=None, timeout=None):
+            halfClosed=None, port=None, timeout=None, httpsRedirect=None):
         """
         Provides a way to modify the following attributes of a load balancer:
             - name
@@ -1305,10 +1311,11 @@ class CloudLoadBalancerClient(BaseClient):
             - halfClosed
             - port
             - timeout
+            - httpsRedirect
         """
         return self._manager.update(loadbalancer, name=name,
                 algorithm=algorithm, protocol=protocol, halfClosed=halfClosed,
-                port=port, timeout=timeout)
+                port=port, timeout=timeout, httpsRedirect=httpsRedirect)
 
 
     @assure_loadbalancer

--- a/tests/unit/test_cloud_loadbalancers.py
+++ b/tests/unit/test_cloud_loadbalancers.py
@@ -137,9 +137,11 @@ class CloudLoadBalancerTest(unittest.TestCase):
         name = utils.random_unicode()
         algorithm = utils.random_unicode()
         timeout = utils.random_unicode()
-        clt.update(lb, name=name, algorithm=algorithm, timeout=timeout)
+        httpsRedirect = utils.random_unicode()
+        clt.update(lb, name=name, algorithm=algorithm, timeout=timeout, httpsRedirect=httpsRedirect)
         mgr.update.assert_called_once_with(lb, name=name, algorithm=algorithm,
-                protocol=None, halfClosed=None, port=None, timeout=timeout)
+                protocol=None, halfClosed=None, port=None, timeout=timeout,
+                httpsRedirect=httpsRedirect)
 
     def test_lb_update_lb(self):
         lb = self.loadbalancer
@@ -148,9 +150,11 @@ class CloudLoadBalancerTest(unittest.TestCase):
         name = utils.random_unicode()
         algorithm = utils.random_unicode()
         timeout = utils.random_unicode()
-        lb.update(name=name, algorithm=algorithm, timeout=timeout)
+        httpsRedirect = utils.random_unicode()
+        lb.update(name=name, algorithm=algorithm, timeout=timeout, httpsRedirect=httpsRedirect )
         mgr.update.assert_called_once_with(lb, name=name, algorithm=algorithm,
-                protocol=None, halfClosed=None, port=None, timeout=timeout)
+                protocol=None, halfClosed=None, port=None, timeout=timeout,
+                httpsRedirect=httpsRedirect)
 
     def test_mgr_update_lb(self):
         lb = self.loadbalancer
@@ -1169,6 +1173,7 @@ class CloudLoadBalancerTest(unittest.TestCase):
         fake_metadata = {"fake": utils.random_unicode()}
         fake_timeout = 42
         fake_sessionPersistence = True
+        fake_httpsRedirect = True
         expected = {"loadBalancer": {
                 "name": fake_name,
                 "port": fake_port,
@@ -1184,6 +1189,7 @@ class CloudLoadBalancerTest(unittest.TestCase):
                 "metadata": fake_metadata,
                 "timeout": fake_timeout,
                 "sessionPersistence": fake_sessionPersistence,
+                "httpsRedirect": fake_httpsRedirect,
                 }}
         ret = mgr._create_body(fake_name, port=fake_port,
                 protocol=fake_protocol, nodes=fake_nodes,
@@ -1194,7 +1200,8 @@ class CloudLoadBalancerTest(unittest.TestCase):
                 connectionThrottle=fake_connectionThrottle,
                 healthMonitor=fake_healthMonitor, metadata=fake_metadata,
                 timeout=fake_timeout,
-                sessionPersistence=fake_sessionPersistence)
+                sessionPersistence=fake_sessionPersistence,
+                httpsRedirect=fake_httpsRedirect)
         self.assertEqual(ret, expected)
 
     def test_bad_node_condition(self):
@@ -1216,6 +1223,7 @@ class CloudLoadBalancerTest(unittest.TestCase):
         fake_metadata = {"fake": utils.random_unicode()}
         fake_timeout = 42
         fake_sessionPersistence = True
+        fake_httpsRedirect = True
         self.assertRaises(exc.InvalidNodeCondition, mgr._create_body,
                 fake_name, port=fake_port, protocol=fake_protocol,
                 nodes=fake_nodes, virtual_ips=fake_virtual_ips,
@@ -1225,7 +1233,8 @@ class CloudLoadBalancerTest(unittest.TestCase):
                 connectionThrottle=fake_connectionThrottle,
                 healthMonitor=fake_healthMonitor, metadata=fake_metadata,
                 timeout=fake_timeout,
-                sessionPersistence=fake_sessionPersistence)
+                sessionPersistence=fake_sessionPersistence,
+                httpsRedirect=fake_httpsRedirect)
 
     def test_missing_lb_parameters(self):
         mgr = self.client._manager
@@ -1245,6 +1254,7 @@ class CloudLoadBalancerTest(unittest.TestCase):
         fake_metadata = {"fake": utils.random_unicode()}
         fake_timeout = 42
         fake_sessionPersistence = True
+        fake_httpsRedirect = True
         self.assertRaises(exc.MissingLoadBalancerParameters, mgr._create_body,
                 fake_name, port=fake_port, protocol=fake_protocol,
                 nodes=fake_nodes, virtual_ips=fake_virtual_ips,
@@ -1254,7 +1264,8 @@ class CloudLoadBalancerTest(unittest.TestCase):
                 connectionThrottle=fake_connectionThrottle,
                 healthMonitor=fake_healthMonitor, metadata=fake_metadata,
                 timeout=fake_timeout,
-                sessionPersistence=fake_sessionPersistence)
+                sessionPersistence=fake_sessionPersistence,
+                httpsRedirect=fake_httpsRedirect)
 
     def test_client_get_usage(self):
         clt = self.client


### PR DESCRIPTION
**Issue:** https://github.com/rackspace/pyrax/issues/277

Added **httpsRedirect** param to load balancer _client_ and _manager_.
Updated unit tests.
Ran nosetests -w tests/unit, all tests pass.
Ran pep8 -r --show-source --max-line-length=84 \ --ignore=E123,E124,E126,E127,E128,E303,E302 pyrax/
- No suggestions were provided.
