### PR TITLE
Handle empty bodies in GET calls to cloud_dns

### DIFF
--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -34,6 +34,8 @@ import pyrax.utils as utils
 DEFAULT_TIMEOUT = 5
 # How long (in seconds) to wait in between checks for async completion
 DEFAULT_DELAY = 0.5
+# How many times to retry a GET before raising an error
+DEFAULT_RETRY = 3
 
 
 def assure_domain(fnc):
@@ -369,7 +371,7 @@ class CloudDNSManager(BaseManager):
         Handles the communication with the API when getting
         a full listing of the resources managed by this class.
         """
-        resp, resp_body = self.api.method_get(uri)
+        resp, resp_body = self._retry_get(uri)
         if obj_class is None:
             obj_class = self.resource_class
 
@@ -421,10 +423,22 @@ class CloudDNSManager(BaseManager):
         the BaseManager method must be overridden here.
         """
         uri = "%s?showRecords=false&showSubdomains=false" % uri
-        resp, body = self.api.method_get(uri)
+        resp, body = self._retry_get(uri)
         body["records"] = []
         return self.resource_class(self, body, loaded=True)
 
+    def _retry_get(self, uri):
+        """
+        Handles GET calls to the Cloud DNS API in order to retry on empty
+        body responses.
+        """
+        for i in xrange(DEFAULT_RETRY):
+            resp, body = self.api.method_get(uri)
+            if body:
+                return resp, body
+        # Tried too many times
+        raise exc.ServiceResponseFailure("The Cloud DNS service failed to"
+                                          " respond to the request.")
 
     def _async_call(self, uri, body=None, method="GET", error_class=None,
             has_response=True, *args, **kwargs):
@@ -439,7 +453,7 @@ class CloudDNSManager(BaseManager):
         to handle the result.
         """
         api_methods = {
-                "GET": self.api.method_get,
+                "GET": self._retry_get,
                 "POST": self.api.method_post,
                 "PUT": self.api.method_put,
                 "DELETE": self.api.method_delete,
@@ -456,7 +470,7 @@ class CloudDNSManager(BaseManager):
         while (resp_body["status"] == "RUNNING") and not timed_out:
             resp_body = None
             while resp_body is None and not timed_out:
-                resp, resp_body = self.api.method_get(massagedURL)
+                resp, resp_body = self._retry_get(massagedURL)
                 if self._timeout:
                     timed_out = ((time.time() - start) > self._timeout)
                     time.sleep(self._delay)
@@ -593,7 +607,7 @@ class CloudDNSManager(BaseManager):
         domain_id = utils.get_id(domain)
         dt = utils.iso_time_string(date_or_datetime, show_tzinfo=True)
         uri = "/domains/%s/changes?since=%s" % (domain_id, dt)
-        resp, body = self.api.method_get(uri)
+        resp, body = self._retry_get(uri)
         return body.get("changes", [])
 
 
@@ -673,7 +687,7 @@ class CloudDNSManager(BaseManager):
 
 
     def _list_subdomains(self, uri, domain_id):
-        resp, body = self.api.method_get(uri)
+        resp, body = self._retry_get(uri)
         self._reset_paging("subdomain", body)
         subdomains = body.get("domains", [])
         return [CloudDNSDomain(self, subdomain, loaded=False)
@@ -717,7 +731,7 @@ class CloudDNSManager(BaseManager):
 
 
     def _list_records(self, uri):
-        resp, body = self.api.method_get(uri)
+        resp, body = self._retry_get(uri)
         self._reset_paging("record", body)
         # The domain ID will be in the URL
         pat = "domains/([^/]+)/records"
@@ -770,12 +784,12 @@ class CloudDNSManager(BaseManager):
         uri = "/domains/%s/records?type=%s" % (dom_id, record_type)
         if query_string:
             uri = "%s&%s" % (uri, query_string)
-        resp, body = self.api.method_get(uri)
+        resp, body = self._retry_get(uri)
         records = body.get("records", [])
         self._reset_paging("record", body)
         rec_paging = self._paging.get("record", {})
         while rec_paging.get("next_uri"):
-            resp, body = self.api.method_get(rec_paging.get("next_uri"))
+            resp, body = self._retry_get(rec_paging.get("next_uri"))
             self._reset_paging("record", body)
             records.extend(body.get("records", []))
         for record in records:
@@ -817,7 +831,7 @@ class CloudDNSManager(BaseManager):
         rec_id = utils.get_id(record)
         domain_id = utils.get_id(domain)
         uri = "/domains/%s/records/%s" % (domain_id, rec_id)
-        resp, resp_body = self.api.method_get(uri)
+        resp, resp_body = self._retry_get(uri)
         resp_body['domain_id'] = domain_id
         return CloudDNSRecord(self, resp_body, loaded=False)
 
@@ -899,7 +913,7 @@ class CloudDNSManager(BaseManager):
         href, svc_name = self._get_ptr_details(device, device_type)
         uri = "/rdns/%s?href=%s" % (svc_name, href)
         try:
-            resp, resp_body = self.api.method_get(uri)
+            resp, resp_body = self._retry_get(uri)
         except exc.NotFound:
             return []
         records = [CloudDNSPTRRecord(rec, device)
@@ -1016,6 +1030,18 @@ class CloudDNSClient(BaseClient):
         self._manager = CloudDNSManager(self, resource_class=CloudDNSDomain,
                 response_key="domains", plural_response_key="domains",
                 uri_base="domains")
+
+    def method_get(self, uri, **kwargs):
+        """
+        Overload the method_get function in order to retry on empty body
+        responses from the Cloud DNS API
+        """
+        for i in xrange(3):
+            resp, body = super(CloudDNSClient, self).method_get(uri, **kwargs)
+            if body:
+                return resp, body
+        raise exc.ServiceResponseFailure("The Cloud DNS service failed to"
+                                         " respond to the request.")
 
 
     def set_timeout(self, timeout):

--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -284,6 +284,9 @@ class QueueClientIDNotDefined(PyraxException):
 class ServiceNotAvailable(PyraxException):
     pass
 
+class ServiceResponseFailure(PyraxException):
+    pass
+
 class SnapshotNotAvailable(PyraxException):
     pass
 


### PR DESCRIPTION
Occasionally cloud dns API will return an empty body on a GET call.
Retrying immediately usually resolves this, but in the case that doesn't
work raise a specific exception.

cloud dns manager and client both had their own GET calls, so both had
to be replaced.

Some tests were mocking an empty body for get calls, which started
throwing exceptions with this new code, so those tests had to be
adjusted to put in something for the body, even if it is not used.
