### PR TITLE
Files that are exactly the chunk size can be uploaded as is

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -756,7 +756,7 @@ class CFClient(object):
                     fsize = get_file_size(fileobj)
                 else:
                     fsize = content_length
-            if fsize < self.max_file_size:
+            if fsize <= self.max_file_size:
                 # We can just upload it as-is.
                 return self.connection.put_object(cont.name, obj_name,
                         contents=fileobj, content_type=content_type,


### PR DESCRIPTION
Previously, a file was uploaded as a single chunk if

```
fsize < self.max_file_size
```

This is wrong: files that are exactly the max_file_size can also be
uploaded as a single chunk.  The fix is to replace < with <=:

```
fsize <= self.max_file_size
```

This bug is problematic when attempting to replicate pyrax's normal
chunk uploading behavior, while still using pyrax to upload chunks.

This is a resubmission of https://github.com/rackspace/pyrax/pull/270.
