### PR TITLE
Move fakes.py into the pyrax module

### DIFF
--- a/pyrax/fakes.py
+++ b/pyrax/fakes.py
@@ -774,8 +774,11 @@ class FakeIdentityResponse(FakeResponse):
     def read(self):
         return json.dumps(self.content)
 
-_module_pth = os.path.dirname(pyrax.__file__)
-_img_path = os.path.join(_module_pth, "..", "tests", "unit", "python-logo.png")
-png_content = None
-with open(_img_path, "rb") as pfile:
-    png_content = pfile.read()
+
+def get_png_content():
+    _module_pth = os.path.dirname(pyrax.__file__)
+    _img_path = os.path.join(_module_pth, "..", "tests", "unit", "python-logo.png")
+    png_content = None
+    with open(_img_path, "rb") as pfile:
+        png_content = pfile.read()
+    return png_content

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -17,7 +17,7 @@ from pyrax.autoscale import ScalingGroupManager
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-import fakes
+from pyrax import fakes
 
 
 

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -16,13 +16,13 @@ from pyrax.cf_wrapper.container import Container
 import pyrax.utils as utils
 import pyrax.exceptions as exc
 
-from fakes import fake_attdict
-from fakes import FakeBulkDeleter
-from fakes import FakeContainer
-from fakes import FakeFolderUploader
-from fakes import FakeIdentity
-from fakes import FakeResponse
-from fakes import FakeStorageObject
+from pyrax.fakes import fake_attdict
+from pyrax.fakes import FakeBulkDeleter
+from pyrax.fakes import FakeContainer
+from pyrax.fakes import FakeFolderUploader
+from pyrax.fakes import FakeIdentity
+from pyrax.fakes import FakeResponse
+from pyrax.fakes import FakeStorageObject
 
 
 class CF_ClientTest(unittest.TestCase):

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -14,11 +14,11 @@ from pyrax.cf_wrapper.container import Container
 from pyrax.cf_wrapper.container import Fault
 import pyrax.utils as utils
 import pyrax.exceptions as exc
-from tests.unit.fakes import fake_attdict
-from tests.unit.fakes import FakeContainer
-from tests.unit.fakes import FakeIdentity
-from tests.unit.fakes import FakeResponse
-from tests.unit.fakes import FakeStorageObject
+from pyrax.fakes import fake_attdict
+from pyrax.fakes import FakeContainer
+from pyrax.fakes import FakeIdentity
+from pyrax.fakes import FakeResponse
+from pyrax.fakes import FakeStorageObject
 
 
 

--- a/tests/unit/test_cf_storage_object.py
+++ b/tests/unit/test_cf_storage_object.py
@@ -12,10 +12,10 @@ import pyrax
 from pyrax.cf_wrapper.storage_object import StorageObject
 import pyrax.exceptions as exc
 import pyrax.utils as utils
-from tests.unit.fakes import fake_attdict
-from tests.unit.fakes import FakeContainer
-from tests.unit.fakes import FakeIdentity
-from tests.unit.fakes import FakeResponse
+from pyrax.fakes import fake_attdict
+from pyrax.fakes import FakeContainer
+from pyrax.fakes import FakeIdentity
+from pyrax.fakes import FakeResponse
 
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,7 +17,7 @@ import pyrax.utils as utils
 import pyrax.exceptions as exc
 from pyrax import client
 
-from tests.unit import fakes
+from pyrax import fakes
 
 DUMMY_URL = "http://example.com"
 ID_CLS = pyrax.settings.get("identity_class") or pyrax.rax_identity.RaxIdentity

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -23,7 +23,7 @@ import pyrax.exceptions as exc
 from pyrax.manager import BaseManager
 import pyrax.utils as utils
 
-import fakes
+from pyrax import fakes
 
 example_uri = "http://example.com"
 

--- a/tests/unit/test_cloud_databases.py
+++ b/tests/unit/test_cloud_databases.py
@@ -17,7 +17,7 @@ import pyrax.exceptions as exc
 from pyrax.resource import BaseResource
 import pyrax.utils as utils
 
-import fakes
+from pyrax import fakes
 
 example_uri = "http://example.com"
 

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -23,7 +23,7 @@ from pyrax.clouddns import RecordResultsIterator
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-import fakes
+from pyrax import fakes
 
 example_uri = "http://example.com"
 

--- a/tests/unit/test_cloud_loadbalancers.py
+++ b/tests/unit/test_cloud_loadbalancers.py
@@ -16,7 +16,7 @@ from pyrax.cloudloadbalancers import assure_loadbalancer
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-from tests.unit import fakes
+from pyrax import fakes
 
 example_uri = "http://example.com"
 

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -21,7 +21,7 @@ from pyrax.cloudmonitoring import _params_to_dict
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-from tests.unit import fakes
+from pyrax import fakes
 
 
 

--- a/tests/unit/test_cloud_networks.py
+++ b/tests/unit/test_cloud_networks.py
@@ -16,7 +16,7 @@ from pyrax.cloudnetworks import _get_server_networks
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-from tests.unit import fakes
+from pyrax import fakes
 
 example_cidr = "1.1.1.0/8"
 example_uri = "http://example.com"

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -8,7 +8,7 @@ from mock import MagicMock as Mock
 import pyrax.utils as utils
 import pyrax.exceptions as exc
 
-from tests.unit import fakes
+from pyrax import fakes
 
 fake_url = "http://example.com"
 

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -20,7 +20,7 @@ import pyrax.exceptions as exc
 from pyrax import base_identity
 from pyrax.identity import rax_identity
 
-from tests.unit import fakes
+from pyrax import fakes
 
 
 class DummyResponse(object):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -10,7 +10,7 @@ import pyrax.exceptions as exc
 from pyrax import manager
 import pyrax.utils as utils
 
-from tests.unit import fakes
+from pyrax import fakes
 
 fake_url = "http://example.com"
 

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -11,7 +11,7 @@ from mock import MagicMock as Mock
 import pyrax
 import pyrax.exceptions as exc
 import pyrax.utils as utils
-from tests.unit import fakes
+from pyrax import fakes
 
 
 

--- a/tests/unit/test_queues.py
+++ b/tests/unit/test_queues.py
@@ -24,7 +24,7 @@ from pyrax.queueing import _parse_marker
 import pyrax.exceptions as exc
 import pyrax.utils as utils
 
-import fakes
+from pyrax import fakes
 
 
 def _safe_id():

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -9,7 +9,7 @@ import pyrax.utils as utils
 import pyrax.exceptions as exc
 from pyrax import resource
 
-from tests.unit import fakes
+from pyrax import fakes
 
 fake_url = "http://example.com"
 

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -9,7 +9,7 @@ import pyrax.utils as utils
 import pyrax.exceptions as exc
 from pyrax import service_catalog
 
-from tests.unit import fakes
+from pyrax import fakes
 
 fake_url = "http://example.com"
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,7 +15,7 @@ from mock import MagicMock as Mock
 
 import pyrax.utils as utils
 import pyrax.exceptions as exc
-import fakes
+from pyrax import fakes
 
 FAKE_CONTENT = "x" * 100
 
@@ -79,7 +79,7 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(expected, received)
 
     def test_get_checksum_from_binary(self):
-        test = fakes.png_content
+        test = fakes.get_png_content()
         md = hashlib.md5()
         enc = "utf8"
         md.update(test)


### PR DESCRIPTION
It is advantageous for an application that utilizes pyrax, to have access to the fake clients used by the pyrax tests, so that you can perform unit testing on code that utilizes pyrax.

Currently, the fakes.py file is part of the tests and not shipped with pyrax on install.  python-novaclient ships it's entire tests.

As an aside, python-swiftclient does not ship it's tests or fakes with the module during installation.
