### PR TITLE
Allow for identity modules in separate python packages

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -134,9 +134,13 @@ def _id_type(ityp):
 
 
 def _import_identity(import_str):
-    import_str = _id_type(import_str)
-    full_str = "pyrax.identity.%s" % import_str
-    return utils.import_class(full_str)
+    try:
+        import_str = _id_type(import_str)
+        full_str = "pyrax.identity.%s" % import_str
+        return utils.import_class(full_str)
+    except ImportError:
+        pass
+    return utils.import_class(import_str)
 
 
 


### PR DESCRIPTION
A simple modification to allow for identity modules outside of the pyrax package itself.

This would allow third-party to create and package their own identity module for pyrax

(sorry about my previous pull request against master)
