### PR TITLE
Update 'requests' & 'six' required versions on setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
         "python-swiftclient>=1.5.0",
         "httplib2",
         "keyring",
-        "requests>=1.0.0",
-        "six",
+        "requests>=2.2.1",
+        "six>=1.5.2",
     ] + testing_requires,
     packages=[
         "pyrax",


### PR DESCRIPTION
Interacting with cloudfiles fails to load the urllib
& pyrax exceptions modules unless 'requests' & 'six'
are updated
