### PR TITLE
Adding support for extra headers to cf_client and cf_container.

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -629,7 +629,7 @@ class CFClient(object):
     @handle_swiftclient_exception
     def store_object(self, container, obj_name, data, content_type=None,
             etag=None, content_encoding=None, ttl=None, return_none=False,
-            extra_info=None):
+            headers={}, extra_info=None):
         """
         Creates a new object in the specified container, and populates it with
         the given data. A StorageObject reference to the uploaded file
@@ -640,7 +640,6 @@ class CFClient(object):
         underlying swiftclient call.
         """
         cont = self.get_container(container)
-        headers = {}
         if content_encoding is not None:
             headers["Content-Encoding"] = content_encoding
         if ttl is not None:

--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -142,7 +142,7 @@ class Container(object):
 
     def store_object(self, obj_name, data, content_type=None, etag=None,
             content_encoding=None, ttl=None, return_none=False,
-            extra_info=None):
+            headers={}, extra_info=None):
         """
         Creates a new object in this container, and populates it with
         the given data.
@@ -150,7 +150,7 @@ class Container(object):
         return self.client.store_object(self, obj_name, data,
                 content_type=content_type, etag=etag,
                 content_encoding=content_encoding, ttl=ttl,
-                return_none=return_none, extra_info=extra_info)
+                return_none=return_none, headers=headers, extra_info=extra_info)
 
 
     def upload_file(self, file_or_path, obj_name=None, content_type=None,

--- a/tests/unit/test_cf_client.py
+++ b/tests/unit/test_cf_client.py
@@ -510,7 +510,8 @@ class CF_ClientTest(unittest.TestCase):
         etag = utils.get_checksum(content)
         obj = client.store_object(self.cont_name, self.obj_name, content,
                 content_type="test/test", etag=etag,
-                content_encoding="gzip")
+                headers={"Content-Disposition": "attachment; filename=test.txt.gz"},
+                content_encoding="gzip",)
         self.assertEqual(client.connection.put_object.call_count, 1)
         # Add extra_info
         response = {}

--- a/tests/unit/test_cf_container.py
+++ b/tests/unit/test_cf_container.py
@@ -193,7 +193,8 @@ class CF_ContainerTest(unittest.TestCase):
         etag = utils.get_checksum(content)
         obj = cont.store_object(self.obj_name, content,
                 content_type="test/test", etag=etag,
-                content_encoding="gzip")
+                content_encoding="gzip", headers={
+                    "Content-Disposition": "attachment; filename=test.txt.gz"})
         self.assertEqual(cont.client.connection.put_object.call_count, 1)
         cont.client.get_object = gobj
 


### PR DESCRIPTION
Cloud Files are allowed to take additional headers, in particular Content-Disposition.  Rather than handle each individual header as a parameter, we can assign the headers as a dictionary that gets passed in.  This also allows for better futureproofing.

Details: http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_Browser_Bypass_with_the_Content-Disposition_Header-d1e2219.html

Scratching an itch here - I need to be able to display PDFs that have been uploaded inline, and that requires this header.  There currently is no way to set this header with Pyrax.
