### PR TITLE
Allows list_tenants to work for both admin and authenticated users.

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -555,11 +555,12 @@ class BaseAuth(object):
         return None
 
 
-    def list_tenants(self):
+    def list_tenants(self, admin = True):
         """
-        ADMIN ONLY. Returns a list of all tenants.
+        Returns a list of all tenants (admin=True), or the tenant for the
+        currently authenticated user (admin = False).
         """
-        return self._list_tenants(admin=True)
+        return self._list_tenants(admin)
 
 
     def _list_tenants(self, admin):


### PR DESCRIPTION
The internal function _list_tenants works for returning tenants for the currently authenticated user and the admin user, but the previous definition of the public function list_tenants forced the admin argument to true. This modifies that behaviour to allow non-admin users to list their respective tenants.
