### PR TITLE
Modified list_tenants function to take an admin argument.

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -555,11 +555,12 @@ class BaseAuth(object):
         return None
 
 
-    def list_tenants(self):
+    def list_tenants(self, admin=True):
         """
-        ADMIN ONLY. Returns a list of all tenants.
+        Lists all tenants associated with the currently authenticated
+        user (admin=False), or all tenants (admin=True).
         """
-        return self._list_tenants(admin=True)
+        return self._list_tenants(admin)
 
 
     def _list_tenants(self, admin):


### PR DESCRIPTION
Previously, the list_tenants function forced admin=True to the internal _list_tenants, which meant the list_tenants function could not be used to retrieve tenants for a non-admin user.
