### PR TITLE
Using Requests Objects in Monitoring

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -564,7 +564,7 @@ class CloudMonitorEntityManager(BaseManager):
             body["metadata"] = metadata
         resp = self.api.method_post(uri, body=body)
 
-        if resp.status_code == "201":
+        if resp.status_code == 201:
             alarm_id = resp.headers["x-object-id"]
             return self.get_alarm(entity, alarm_id)
 

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -682,8 +682,9 @@ class CloudMonitoringTest(unittest.TestCase):
         exp_body = {"check_id": check, "notification_plan_id": np, "criteria":
                 criteria, "disabled": disabled, "label": label,
                 "metadata": metadata}
-        mgr.create_alarm(ent, check, np, criteria=criteria, disabled=disabled,
+        alarm = mgr.create_alarm(ent, check, np, criteria=criteria, disabled=disabled,
                 label=label, name=name, metadata=metadata)
+        alarm.assertEqual(alarm.entity, ent)
         clt.method_post.assert_called_once_with(exp_uri, body=exp_body)
 
     def test_entity_mgr_update_alarm(self):


### PR DESCRIPTION
This updates the cloudmonitoring module and the tests for the cloud monitoring module to reflect the changeover to using requests.

---

While trying to work with monitoring, I couldn't get any of the example code to run because access to the response object has completely changed.

```
In [8]:   entity = cm.create_entity(name="somehost.domain.com",
   ...:                             ip_addresses={"example": "192.168.1.1"})
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-8-67b5b1d6fafa> in <module>()
      1 entity = cm.create_entity(name="somehost.domain.com",
----> 2                           ip_addresses={"example": "192.168.1.1"})

/usr/local/lib/python2.7/site-packages/pyrax/cloudmonitoring.pyc in create_entity(self, label, name, agent, ip_addresses, metadata)
    949                 ip_addresses=ip_addresses, metadata=metadata,
    950                 return_response=True)
--> 951         status = resp["status"]
    952         if status == "201":
    953             ent_id = resp["x-object-id"]

TypeError: 'Response' object has no attribute '__getitem__'
```

What's included here is _only_ a fix for create_entity. It looks like the entire module needs fixing. Let me know what you think and I'll tackle the rest.
