### PR TITLE
dns: _get_service_endpoint requires a context

### DIFF
--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -871,12 +871,14 @@ class CloudDNSManager(BaseManager):
         Takes a device and device type and returns the corresponding HREF link
         and service name for use with PTR record management.
         """
+        context = self.api.identity
+        region = self.api.region_name
         if device_type.lower().startswith("load"):
-            ep = pyrax._get_service_endpoint("load_balancer")
+            ep = pyrax._get_service_endpoint(context, "load_balancer", region)
             svc = "loadbalancers"
             svc_name = "cloudLoadBalancers"
         else:
-            ep = pyrax._get_service_endpoint("compute")
+            ep = pyrax._get_service_endpoint(context, "compute", region)
             svc = "servers"
             svc_name = "cloudServersOpenStack"
         href = "%s/%s/%s" % (ep, svc, utils.get_id(device))


### PR DESCRIPTION
In `_get_ptr_details`, `pyrax._get_service_endpoint` is being called without the "context" argument.  When interacting with `PTR` related actions such as `dns.list_ptr_records` this causes and exception to be raised:

```
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/clouddns.py", line 1298, in list_ptr_records
    return self._manager.list_ptr_records(device)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/clouddns.py", line 915, in list_ptr_records
    href, svc_name = self._get_ptr_details(device, device_type)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/clouddns.py", line 879, in _get_ptr_details
    ep = pyrax._get_service_endpoint("compute")
TypeError: _get_service_endpoint() takes at least 2 arguments (1 given)
```

This pull request adds the "context" parameter to the `_get_service_endpoint` calls.
