### PR TITLE
get_stats() not accessible by CloudLoadBalancer

### DIFF
--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -83,7 +83,8 @@ class CloudLoadBalancer(BaseResource):
         "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD".
         """
         return self.manager.get_usage(self, start=start, end=end)
-    
+
+
     def get_stats(self):
         """
         Return the stats for this loadbalancer


### PR DESCRIPTION
It was only accessible by instance of CloudLoadBalancerManager. Therefore user had to go through load_balancer_instance.manager.get_stats() to get that information. This is not user friendly and not what is reflected in the docs.
