### PR TITLE
Fix Invalid flavorRef "None" in launchConfiguration

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -441,7 +441,7 @@ class ScalingGroupManager(BaseManager):
         largs = scaling_group.launchConfiguration.get("args", {})
         srv_args = largs.get("server", {})
         lb_args = largs.get("loadBalancers", {})
-        flav = "%s" % flavor or srv_args.get("flavorRef")
+        flav = "%s" % flavor if flavor else srv_args.get("flavorRef")
         dconf = disk_config or srv_args.get("OS-DCF:diskConfig")
         pers = personality or srv_args.get("personality")
         body = {"type": "launch_server",


### PR DESCRIPTION
This pull request resolves an issue where when updating the launch configuration of an autoscale group while not providing `flavor` raises an exception:

```
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/autoscale.py", line 120, in update_launch_config
    load_balancers=load_balancers, key_name=key_name)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/autoscale.py", line 464, in update_launch_config
    resp, resp_body = self.api.method_put(uri, body=body)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/client.py", line 248, in method_put
    return self._api_request(uri, "PUT", **kwargs)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/client.py", line 219, in _api_request
    resp, body = self._time_request(safe_uri, method, **kwargs)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/client.py", line 179, in _time_request
    resp, body = self.request(uri, method, **kwargs)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/client.py", line 170, in request
    resp, body = pyrax.http.request(method, uri, *args, **kwargs)
  File "/Users/matt/python_venvs/ansibledev/lib/python2.7/site-packages/pyrax/http.py", line 72, in request
    raise exc.from_response(resp, body)
pyrax.exceptions.BadRequest: Following problems with launch configuration:
Invalid flavorRef "None" in launchConfiguration (HTTP 400)
```

To reproduce:

``` python
au = pyrax.autoscale
sg = au.list()[0]
sg.update_launch_config(image='5cc098a5-7286-4b96-b3a2-49f4c4f82537')
```
