### PR TITLE
get_stats() not accessible by CloudLoadBalancer

### DIFF
--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -85,6 +85,12 @@ class CloudLoadBalancer(BaseResource):
         return self.manager.get_usage(self, start=start, end=end)
 
 
+    def get_stats(self):
+        """
+        Return the stats for this loadbalancer
+        """
+        return self.manager.get_stats(self)
+
     def _add_details(self, info):
         """Override the base behavior to add Nodes, VirtualIPs, etc."""
         for (key, val) in info.iteritems():
@@ -956,7 +962,7 @@ class CloudLoadBalancerManager(BaseManager):
         return body
 
 
-    def get_stats(self, loadbalancer):
+    def get_stats(self, loadbalancer=None):
         """
         Returns statistics for the given load balancer.
         """


### PR DESCRIPTION
It was only accessible by instance of CloudLoadBalancerManager. Therefore user had to go through load_balancer_instance.manager.get_stats() to get that information. This is not user friendly and not what is reflected in the docs.
