### PR TITLE
Store all CDN URIs on first setting a container as CDN-enabled

### DIFF
--- a/pyrax/cf_wrapper/client.py
+++ b/pyrax/cf_wrapper/client.py
@@ -1444,9 +1444,15 @@ class CFClient(object):
                     response.reason))
         ct.cdn_ttl = ttl
         for hdr in response.getheaders():
-            if hdr[0].lower() == "x-cdn-uri":
+            low_hdr = hdr[0].lower()
+            if low_hdr == "x-cdn-uri":
                 ct.cdn_uri = hdr[1]
-                break
+            elif low_hdr == "x-cdn-ssl-uri":
+                ct.cdn_ssl_uri = hdr[1]
+            elif low_hdr == "x-cdn-streaming-uri":
+                ct.cdn_streaming_uri = hdr[1]
+            elif low_hdr == "x-cdn-ios-uri":
+                ct.cdn_ios_uri = hdr[1]
         self.remove_container_from_cache(container)
         # Read the response to force it to close for the next request.
         response.read()


### PR DESCRIPTION
[Resubmitted pull request #390 to working branch]

When setting containers to be CDN-enabled over a low latency connection (such as a cloud server in the same region as a cloud files endpoint over the service network) the SSL, stream and iOS URIs are not set. This is repeatable with the following basic example code:

``` python
import pyrax
pyrax.set_setting('identity_type', 'rackspace')
pyrax.set_credentials('some_username', 'some_apikey', region='LON')
cf = pyrax.cloudfiles
print 'creating...'
container = cf.create_container('testcontainer')
container.make_public(ttl=900)
# container.client.cdn_enabled = True # <-- uncomment this hack to force a lazy re-check by _fetch_cdn_data() to resolve the issue
print 'http:', container.cdn_uri # always set
print 'https:', container.cdn_ssl_uri # returns None over service network, or the URI over a WAN request
print 'stream:', container.cdn_streaming_uri # returns None over service network, or the URI over a WAN request
print 'ios:', container.cdn_ios_uri # returns None over service network, or the URI over a WAN request
print 'cleaning up...'
container.delete()
The issue is caused by client._cdn_set_access() only storing the HTTP URI and so the check at the top of container._fetch_cdn_data() and returns before lazily re-loading the URIs. The hack commented out above forces _fetch_cdn_data() to actually reload the data so it fixes the issue.
```

The documentation here: http://docs.rackspace.com/files/api/v1/cf-devguide/content/PUT_enableDisableCDNcontainer_v1__account___container__CDN_Container_Services-d1e2632.html and testing shows that the initial request to CDN-enable a container also return the missing URIs so there is no reason to not initially store them as well.

This pull request simply stores the SSL, stream and iOS URIs from the initial request to set a container as CDN enabled rather than waiting for them to be set later which also decreases the number of requests to the API.
