### PR TITLE
bulk_delete async support

### DIFF
--- a/pyrax/cf_wrapper/container.py
+++ b/pyrax/cf_wrapper/container.py
@@ -200,7 +200,7 @@ class Container(object):
             errors - a list of any errors returned by the bulk delete call
         """
         nms = self.get_object_names(full_listing=True)
-        self.client.bulk_delete(self, nms, async=False)
+        return self.client.bulk_delete(self, nms, async=async)
 
 
     def remove_from_cache(self, obj):


### PR DESCRIPTION
Ed - while looking through the Pyrax code, I found container.bulk_delete() which takes an async boolean option but does nothing with it; this should fix the problem.
