### PR TITLE
sg.update_launch_config fails with no personality value

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -451,13 +451,14 @@ class ScalingGroupManager(BaseManager):
                         "imageRef": image or srv_args.get("imageRef"),
                         "flavorRef": flav,
                         "OS-DCF:diskConfig": dconf,
-                        "personality": pers,
                         "networks": networks or srv_args.get("networks"),
                         "metadata": metadata or srv_args.get("metadata"),
                     },
                     "loadBalancers": load_balancers or lb_args,
                 },
             }
+        if pers:
+            body["args"]["server"]["personality"] = pers
         key_name = key_name or srv_args.get("key_name")
         if key_name:
             body["args"]["server"] = key_name

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -501,6 +501,39 @@ class AutoscaleTest(unittest.TestCase):
                 personality=personality, networks=networks, load_balancers=lbs)
         mgr.api.method_put.assert_called_once_with(uri, body=body)
 
+    def test_mgr_update_launch_config_no_personality(self):
+        sg = self.scaling_group
+        mgr = sg.manager
+        mgr.get = Mock(return_value=sg)
+        typ = utils.random_unicode()
+        lbs = utils.random_unicode()
+        name = utils.random_unicode()
+        flv = utils.random_unicode()
+        img = utils.random_unicode()
+        dconfig = utils.random_unicode()
+        metadata = utils.random_unicode()
+        networks = utils.random_unicode()
+        sg.launchConfiguration = {}
+        body = {"type": "launch_server",
+                "args": {
+                    "server": {
+                        "name": name,
+                        "imageRef": img,
+                        "flavorRef": flv,
+                        "OS-DCF:diskConfig": dconfig,
+                        "networks": networks,
+                        "metadata": metadata,
+                    },
+                    "loadBalancers": lbs,
+                },
+            }
+        mgr.api.method_put = Mock(return_value=(None, None))
+        uri = "/%s/%s/launch" % (mgr.uri_base, sg.id)
+        mgr.update_launch_config(sg.id, server_name=name, flavor=flv, image=img,
+                disk_config=dconfig, metadata=metadata,
+                networks=networks, load_balancers=lbs)
+        mgr.api.method_put.assert_called_once_with(uri, body=body)
+
     def test_mgr_update_launch_config_key_name(self):
         sg = self.scaling_group
         mgr = sg.manager


### PR DESCRIPTION
sg.update_launch_config causes a "400 Bad Request" when no personality is defined. "None" get's sent as the the personality value if one isn't provided and the existing configuration doesn't have one.
