### PR TITLE
Updated udpate_launch_config(). flavorRef was being set to None

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -441,9 +441,9 @@ class ScalingGroupManager(BaseManager):
         largs = scaling_group.launchConfiguration.get("args", {})
         srv_args = largs.get("server", {})
         lb_args = largs.get("loadBalancers", {})
-        flav = flavor if flavor is not None else srv_args.get("flavorRef")
-        dconf = disk_config if disk_config is not None else srv_args.get("OS-DCF:diskConfig", "AUTO")
-        pers = personality if personality is not None else srv_args.get("personality", [])
+        flav = flavor or srv_args.get("flavorRef")
+        dconf = disk_config or srv_args.get("OS-DCF:diskConfig", "AUTO")
+        pers = personality or srv_args.get("personality", [])
         body = {"type": "launch_server",
                 "args": {
                     "server": {


### PR DESCRIPTION
In autoscale.py, update_launch_metadata will call update_launch_config(). update_launch_config() does not set flavorRef correctly.  Stack Trace:

2014-06-29 23:19:05,042 | DEBUG | "PUT /v1.0/908277/groups/967caa99-eabb-4577-9e61-a405ab0c0a50/launch HTTP/1.1" 400 None
Traceback (most recent call last):
  File "rsautoscale.py", line 62, in <module>
    set_f5_pool(autoscalegroup=scaling_group, poolname='POOL-FOX-WDF-166.78.67.61-80')
  File "rsautoscale.py", line 39, in set_f5_pool
    autoscalegroup.update_launch_metadata({'RackConnectLBPool' : poolname}) 
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/autoscale.py", line 128, in update_launch_metadata
    return self.manager.update_launch_metadata(self, metadata)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/autoscale.py", line 481, in update_launch_metadata
    return self.update_launch_config(scaling_group, metadata=curr_meta)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/autoscale.py", line 448, in update_launch_config
    dconf = disk_config or srv_args.get("OS-DCF:diskConfig")
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/client.py", line 247, in method_put
    return self._api_request(uri, "PUT", *_kwargs)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/client.py", line 218, in _api_request
    resp, body = self._time_request(safe_uri, method, *_kwargs)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/client.py", line 179, in _time_request
    resp, body = self.request(uri, method, *_kwargs)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/client.py", line 170, in request
    resp, body = pyrax.http.request(method, uri, *args, *_kwargs)
  File "/Users/mattchung/.virtualenvs/pyrax1.8.2/lib/python2.7/site-packages/pyrax/http.py", line 72, in request
    raise exc.from_response(resp, body)
pyrax.exceptions.BadRequest: {u'args': {u'loadBalancers': [], u'server': {u'name': u'myautoscale', u'imageRef': u'042395fc-728c-4763-86f9-9b0cacb00701', u'flavorRef': u'2', u'OS-DCF:diskConfig': None, u'personality': None, u'networks': [{u'uuid': u'00000000-0000-0000-0000-000000000000'}, {u'uuid': u'11111111-1111-1111-1111-111111111111'}], u'metadata': {u'RackConnectLBPool': u'POOL-FOX-WDF-166.78.67.61-80'}}}, u'type': u'launch_server'} is not of type {'type': 'object', 'description': "'Launch Server' launch configuration options.  This type of launch configuration will spin up a next-gen server directly with the provided arguments, and add the server to one or more load balancers (if load balancer arguments are specified.", 'properties': {'args': {'additionalProperties': False, 'properties': {'loadBalancers': {'description': 'One or more load balancers to add new servers to. All servers will be added to these load balancers with their ServiceNet addresses, and will be enabled, of primary type, and equally weighted. If new servers are not connected to the ServiceNet, they will not be added to any load balancers.', 'minItems': 0, 'items': {'additionalProperties': False, 'type': 'object', 'description': 'One load balancer all new servers should be added to.', 'properties': {'port': {'required': True, 'type': 'integer', 'description': 'The port number of the service (on the new servers) to load balance on for this particular load balancer.'}, 'loadBalancerId': {'required': True, 'type': 'integer', 'description': 'The ID of the load balancer to which new servers will be added.'}}}, 'required': False, 'uniqueItems': True, 'type': 'array'}, 'server': {'required': True, 'type': 'object', 'description': 'Attributes to provide to nova create server: http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html.Whatever attributes are passed here will apply to all new servers (including the name attribute).', 'properties': {'flavorRef': {'minLength': 1, 'required': True, 'type': 'string', 'pattern': '\S+'}, 'imageRef': {'minLength': 1, 'required': True, 'type': 'string', 'pattern': '\S+'}, 'personality': {'items': {'type': 'object', 'properties': {'path': {'minLength': 1, 'required': True, 'type': 'string', 'maxLength': 255}, 'contents': {'required': True, 'type': 'string'}}}, 'required': False, 'type': 'array'}}}}}, 'type': {'enum': ['launch_server']}}} (HTTP 400)
(pyrax1.8.2)matts-mbp:pyrax1.8.2 mattchung$ vi lib/python2.7/site-packages/pyrax/autoscale.py
(pyrax1.8.2)matts-mbp:pyrax1.8.2 mattchung$ python rsautoscale.py --config config/foxneotechops.ini --region "ORD" --autoscalename myautoscale
Traceback (most recent call last):
