### PR TITLE
Base64-encode personality file contents in AS client

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -17,6 +17,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import base64
+
 import pyrax
 from pyrax.client import BaseClient
 from pyrax.cloudloadbalancers import CloudLoadBalancer
@@ -765,6 +767,10 @@ class ScalingGroupManager(BaseManager):
             metadata = {}
         if personality is None:
             personality = []
+        else:
+            for file in personality:
+                if 'contents' in file:
+                    file['contents'] = base64.b64encode(file['contents'])
         if scaling_policies is None:
             scaling_policies = []
         group_config = self._create_group_config_body(name, cooldown,

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -1061,7 +1061,7 @@ class AutoscaleTest(unittest.TestCase):
         flavor = utils.random_unicode()
         disk_config = None
         metadata = None
-        personality = None
+        personality = [{'path': '/tmp/testing', 'contents': 'testtest'}]
         scaling_policies = None
         networks = utils.random_unicode()
         lb = fakes.FakeLoadBalancer()
@@ -1086,7 +1086,8 @@ class AutoscaleTest(unittest.TestCase):
                             "imageRef": image,
                             "metadata": {},
                             "name": server_name,
-                            "personality": [],
+                            "personality": [{'path': '/tmp/testing',
+                                             'contents': 'dGVzdHRlc3Q='}],
                             "networks": networks,
                             "key_name": key_name}
                         },


### PR DESCRIPTION
The Autoscale API expects the personality file contents to be
base64-encoded.  Transparently base64-encode the file contents similarly
to how python-novaclient does it.
