### PR TITLE
modified list_entities to gather ALL entities via pagination

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -929,8 +929,34 @@ class CloudMonitorClient(BaseClient):
         return resp_body["values"]
 
 
-    def list_entities(self):
-        return self._entity_manager.list()
+    def list_entities(self, page_limit = 100):
+        '''
+        Returns all available entities in a list
+        The 'page_limit' parameter defines how many entities may be
+        requested in one backend api call.
+
+        This may result in multiple requests to the backend API to 
+        gather all entities, depending on total number and page_limit
+        '''
+        result = []
+        finished = False
+        marker = None
+        while not finished:
+            # get next group of entities from the manager
+            req_res = self._entity_manager.list(
+                    limit = page_limit, marker = marker)
+            if (len(req_res) > 0):
+                # elements were returned, so store them and check the marker
+                result.extend(req_res)
+                marker = self._entity_manager.get_next_marker()
+                if (marker == None):
+                    finished = True
+            else:
+                # no elements = end of the list
+                finished = True
+
+        # at this point, result is either an empty list or contains all entities
+        return result
 
 
     def get_entity(self, entity):

--- a/pyrax/manager.py
+++ b/pyrax/manager.py
@@ -44,6 +44,7 @@ class BaseManager(object):
     plural_response_key = None
     uri_base = None
     _hooks_map = {}
+    next_marker = None    # provides the next marker for paginated listing
 
 
     def __init__(self, api, resource_class=None, response_key=None,
@@ -57,6 +58,8 @@ class BaseManager(object):
             self.plural_response_key = "%ss" % response_key
         self.uri_base = uri_base
 
+    def get_next_marker(self):
+        return self.next_marker
 
     def list(self, limit=None, marker=None, return_raw=False):
         """
@@ -161,6 +164,11 @@ class BaseManager(object):
         #           unlike other services which just return the list...
         if isinstance(data, dict):
             try:
+                # if it is present, store the next marker for pagination
+                self.next_marker = None
+                if ('metadata' in data):
+                   if ('next_marker' in data['metadata']):
+                       self.next_marker = data['metadata']['next_marker']
                 data = data["values"]
             except KeyError:
                 pass

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -54,6 +54,18 @@ class ManagerTest(unittest.TestCase):
         expected_uri = "/test?limit=%s&marker=%s" % (fake_limit, fake_marker)
         mgr._list.assert_called_once_with(expected_uri, return_raw=False)
 
+    def test_get_next_marker(self):
+        mgr = self.manager
+        marker = random.randint(100, 200)
+        resp_body = Mock()
+        resp_body_data = dict({
+                "values": [ random.randint(10, 20), random.randint(10, 20) ],
+                "metadata": { "next_marker": marker }
+                })
+        resp_body.get = Mock(return_value = resp_body_data)
+        mgr._data_from_response(resp_body)
+        self.assertEqual(mgr.get_next_marker(), marker);
+
     def test_head(self):
         mgr = self.manager
         mgr._head = Mock()


### PR DESCRIPTION
## Problem

Currently when using the cloudmonitorclient class, a request for the list of entities returns only the first page. This was un-intuitive, as it was expected to provide all entities.
## Approach

By modifying BaseManager to save it's 'next_marker' on a paginated result, it is able to provide it to CloudMonitorClient which can then use it to request ALL entities via the necessary number of paginated api requests.
The returned list is the concatenated result from each api page result.
## Risks

BaseManager: should be low risk. only capturing the marker if it is indeed set
CloudMonitorClient: Will loop API requests until the api gives either no next_marker or a None. Could be until end of time if the API keeps giving next markers
