### PR TITLE
passes missing chunk_size.

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -1849,18 +1849,20 @@ class StorageObjectManager(BaseManager):
         if ttl is not None:
             headers["X-Delete-After"] = ttl
         if src is data:
-            self._upload(obj_name, data, content_type, content_encoding,
-                    content_length, etag, chunked, chunk_size, headers)
+            self._upload(obj_name, data, content_type, 
+                    content_encoding, content_length, etag, chunked, 
+                    chunk_size, headers)
         else:
             if isinstance(file_or_path, file):
                 self._upload(obj_name, file_or_path, content_type,
                         content_encoding, content_length, etag, False,
-                        headers)
+                        chunk_size, headers)
             else:
                 # Need to wrap the call in a context manager
                 with open(file_or_path, "rb") as ff:
-                    self._upload(obj_name, ff, content_type, content_encoding,
-                            content_length, etag, False, chunk_size, headers)
+                    self._upload(obj_name, ff, content_type, 
+                            content_encoding, content_length, etag, False, 
+                            chunk_size, headers)
         if return_none:
             return
         return self.get(obj_name)


### PR DESCRIPTION
formats the sets of parameters the same so that you can see they are all there.
including the missing one that fixes this error:

```
obj = container.upload_file(pf, obj_name = self.key_id)
```

  File "/home/carl/.virtualenvs/veyepar/local/lib/python2.7/site-packages/pyrax/object_storage.py", line 477, in upload_file
    return_none=return_none)
  File "/home/carl/.virtualenvs/veyepar/local/lib/python2.7/site-packages/pyrax/object_storage.py", line 429, in create
    return_none=return_none)
  File "/home/carl/.virtualenvs/veyepar/local/lib/python2.7/site-packages/pyrax/object_storage.py", line 1858, in create
    headers)
TypeError: _upload() takes exactly 10 arguments (9 given)
