### PR TITLE
Add config_drive and user_data support to autoscale

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -107,7 +107,7 @@ class ScalingGroup(BaseResource):
 
     def update_launch_config(self, server_name=None, image=None, flavor=None,
             disk_config=None, metadata=None, personality=None, networks=None,
-            load_balancers=None, key_name=None):
+            load_balancers=None, key_name=None, config_drive=False, user_data=None):
         """
         Updates the server launch configuration for this scaling group.
         One or more of the available attributes can be specified.
@@ -119,7 +119,8 @@ class ScalingGroup(BaseResource):
         return self.manager.update_launch_config(self, server_name=server_name,
                 image=image, flavor=flavor, disk_config=disk_config,
                 metadata=metadata, personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
 
 
     def update_launch_metadata(self, metadata):
@@ -410,7 +411,7 @@ class ScalingGroupManager(BaseManager):
     def replace_launch_config(self, scaling_group, launch_config_type,
             server_name, image, flavor, disk_config=None, metadata=None,
             personality=None, networks=None, load_balancers=None,
-            key_name=None):
+            key_name=None, config_drive=False, user_data=None):
         """
         Replace an existing launch configuration. All of the attributes must be
         specified. If you wish to delete any of the optional attributes, pass
@@ -422,13 +423,15 @@ class ScalingGroupManager(BaseManager):
                 launch_config_type=launch_config_type, server_name=server_name,
                 image=image, flavor=flavor, disk_config=disk_config,
                 metadata=metadata, personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
         resp, resp_body = self.api.method_put(uri, body=body)
 
 
     def update_launch_config(self, scaling_group, server_name=None, image=None,
             flavor=None, disk_config=None, metadata=None, personality=None,
-            networks=None, load_balancers=None, key_name=None):
+            networks=None, load_balancers=None, key_name=None, config_drive=False,
+            user_data=None):
         """
         Updates the server launch configuration for an existing scaling group.
         One or more of the available attributes can be specified.
@@ -446,6 +449,10 @@ class ScalingGroupManager(BaseManager):
         flav = flavor or srv_args.get("flavorRef")
         dconf = disk_config or srv_args.get("OS-DCF:diskConfig", "AUTO")
         pers = personality or srv_args.get("personality", [])
+        cfg_drv = config_drive or srv_args.get("config_drive")
+        if user_data:
+            user_data = base64.b64encode(user_data)
+        usr_data = user_data or srv_args.get("user_data")
         body = {"type": "launch_server",
                 "args": {
                     "server": {
@@ -459,11 +466,15 @@ class ScalingGroupManager(BaseManager):
                     "loadBalancers": load_balancers or lb_args,
                 },
             }
+        if cfg_drv:
+            body["args"]["server"]["config_drive"] = cfg_drv
+        if usr_data:
+            body["args"]["server"]["user_data"] = usr_data
         if pers:
             body["args"]["server"]["personality"] = pers
         key_name = key_name or srv_args.get("key_name")
         if key_name:
-            body["args"]["server"] = key_name
+            body["args"]["server"]["key_name"] = key_name
         resp, resp_body = self.api.method_put(uri, body=body)
         return None
 
@@ -757,7 +768,7 @@ class ScalingGroupManager(BaseManager):
             launch_config_type, server_name, image, flavor, disk_config=None,
             metadata=None, personality=None, networks=None,
             load_balancers=None, scaling_policies=None, group_metadata=None,
-            key_name=None):
+            key_name=None, config_drive=False, user_data=None):
         """
         Used to create the dict required to create any of the following:
             A Scaling Group
@@ -779,7 +790,8 @@ class ScalingGroupManager(BaseManager):
         launch_config = self._create_launch_config_body(launch_config_type,
                 server_name, image, flavor, disk_config=disk_config,
                 metadata=metadata, personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
         body = {
                 "groupConfiguration": group_config,
                 "launchConfiguration": launch_config,
@@ -807,12 +819,14 @@ class ScalingGroupManager(BaseManager):
     def _create_launch_config_body(self, launch_config_type,
             server_name, image, flavor, disk_config=None, metadata=None,
             personality=None, networks=None, load_balancers=None,
-            key_name=None):
+            key_name=None, config_drive=False, user_data=None):
+
         server_args = {
                 "flavorRef": "%s" % flavor,
                 "name": server_name,
                 "imageRef": utils.get_id(image),
                 }
+
         if metadata is not None:
             server_args["metadata"] = metadata
         if personality is not None:
@@ -823,13 +837,18 @@ class ScalingGroupManager(BaseManager):
             server_args["OS-DCF:diskConfig"] = disk_config
         if key_name is not None:
             server_args["key_name"] = key_name
+        if config_drive is not False:
+            server_args['config_drive'] = config_drive
+        if user_data is not None:
+            server_args['user_data'] = base64.b64encode(user_data)
+
         if load_balancers is None:
             load_balancers = []
         load_balancer_args = self._resolve_lbs(load_balancers)
+
         return {"type": launch_config_type,
                 "args": {"server": server_args,
                          "loadBalancers": load_balancer_args}}
-
 
 
 class AutoScalePolicy(BaseResource):
@@ -1065,7 +1084,8 @@ class AutoScaleClient(BaseClient):
 
     def update_launch_config(self, scaling_group, server_name=None, image=None,
             flavor=None, disk_config=None, metadata=None, personality=None,
-            networks=None, load_balancers=None, key_name=None):
+            networks=None, load_balancers=None, key_name=None, config_drive=False,
+            user_data=None):
         """
         Updates the server launch configuration for an existing scaling group.
         One or more of the available attributes can be specified.
@@ -1078,7 +1098,8 @@ class AutoScaleClient(BaseClient):
                 server_name=server_name, image=image, flavor=flavor,
                 disk_config=disk_config, metadata=metadata,
                 personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
 
 
     def update_launch_metadata(self, scaling_group, metadata):

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -114,15 +114,19 @@ class AutoscaleTest(unittest.TestCase):
         networks = utils.random_unicode()
         load_balancers = utils.random_unicode()
         key_name = utils.random_unicode()
+        config_drive = utils.random_unicode()
+        user_data = utils.random_unicode()
         sg.update_launch_config(server_name=server_name, flavor=flavor,
                 image=image, disk_config=disk_config, metadata=metadata,
                 personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
         mgr.update_launch_config.assert_called_once_with(sg,
                 server_name=server_name, flavor=flavor, image=image,
                 disk_config=disk_config, metadata=metadata,
                 personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
 
     def test_update_launch_metadata(self):
         sg = self.scaling_group
@@ -551,7 +555,16 @@ class AutoscaleTest(unittest.TestCase):
         sg.launchConfiguration = {}
         body = {"type": "launch_server",
                 "args": {
-                    "server": key_name,
+                    "server": {
+                        "name": name,
+                        "imageRef": img,
+                        "flavorRef": flv,
+                        "OS-DCF:diskConfig": dconfig,
+                        "networks": networks,
+                        "metadata": metadata,
+                        "key_name": key_name,
+                        "personality": personality,
+                    },
                     "loadBalancers": lbs,
                 },
             }
@@ -1462,15 +1475,19 @@ class AutoscaleTest(unittest.TestCase):
         networks = utils.random_unicode()
         load_balancers = utils.random_unicode()
         key_name = utils.random_unicode()
+        user_data = utils.random_unicode()
+        config_drive = utils.random_unicode()
         clt.update_launch_config(sg, server_name=server_name, flavor=flavor,
                 image=image, disk_config=disk_config, metadata=metadata,
                 personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
         mgr.update_launch_config.assert_called_once_with(sg,
                 server_name=server_name, flavor=flavor, image=image,
                 disk_config=disk_config, metadata=metadata,
                 personality=personality, networks=networks,
-                load_balancers=load_balancers, key_name=key_name)
+                load_balancers=load_balancers, key_name=key_name,
+                config_drive=config_drive, user_data=user_data)
 
     def test_clt_update_launch_metadata(self):
         clt = fakes.FakeAutoScaleClient()


### PR DESCRIPTION
This pull request adds support for `user_data` and `config_drive` to autoscale.  Although not explicitly documented in the autoscale API documentation it is indeed accepted.

In addition to this change, there is a small bugfix with updating the launch config, where if `key_name` was set, the body was incorrectly updated causing the API to respond with a 400. 
