### PR TITLE
Fixed 400 Bad request for updating AutoScale Launch config

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -453,6 +453,7 @@ class ScalingGroupManager(BaseManager):
         if user_data:
             user_data = base64.b64encode(user_data)
         usr_data = user_data or srv_args.get("user_data")
+        update_metadata = metadata or srv_args.get("metadata")
         body = {"type": "launch_server",
                 "args": {
                     "server": {
@@ -461,7 +462,6 @@ class ScalingGroupManager(BaseManager):
                         "flavorRef": flav,
                         "OS-DCF:diskConfig": dconf,
                         "networks": networks or srv_args.get("networks"),
-                        "metadata": metadata or srv_args.get("metadata"),
                     },
                     "loadBalancers": load_balancers or lb_args,
                 },
@@ -472,6 +472,8 @@ class ScalingGroupManager(BaseManager):
             body["args"]["server"]["user_data"] = usr_data
         if pers:
             body["args"]["server"]["personality"] = pers
+        if update_metadata:
+            body["args"]["server"]["metadata"] = update_metadata
         key_name = key_name or srv_args.get("key_name")
         if key_name:
             body["args"]["server"]["key_name"] = key_name

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -538,6 +538,36 @@ class AutoscaleTest(unittest.TestCase):
                 networks=networks, load_balancers=lbs)
         mgr.api.method_put.assert_called_once_with(uri, body=body)
 
+    def test_mgr_update_launch_config_no_metadata(self):
+        sg = self.scaling_group
+        mgr = sg.manager
+        mgr.get = Mock(return_value=sg)
+        typ = utils.random_unicode()
+        lbs = utils.random_unicode()
+        name = utils.random_unicode()
+        flv = utils.random_unicode()
+        img = utils.random_unicode()
+        dconfig = utils.random_unicode()
+        networks = utils.random_unicode()
+        sg.launchConfiguration = {}
+        body = {"type": "launch_server",
+                "args": {
+                    "server": {
+                        "name": name,
+                        "imageRef": img,
+                        "flavorRef": flv,
+                        "OS-DCF:diskConfig": dconfig,
+                        "networks": networks,
+                    },
+                    "loadBalancers": lbs,
+                },
+            }
+        mgr.api.method_put = Mock(return_value=(None, None))
+        uri = "/%s/%s/launch" % (mgr.uri_base, sg.id)
+        mgr.update_launch_config(sg.id, server_name=name, flavor=flv, image=img,
+                disk_config=dconfig, networks=networks, load_balancers=lbs)
+        mgr.api.method_put.assert_called_once_with(uri, body=body)
+
     def test_mgr_update_launch_config_key_name(self):
         sg = self.scaling_group
         mgr = sg.manager


### PR DESCRIPTION
Null value no longer excepted for "metadata" when updating a AutoScale launch config. You will receive a "400 Bad Request" if you try updating a AutoScale launch config within the last 10 days with Rackspace as your host.
