### PR TITLE
get_launch_config should return all server values the API provides

### DIFF
--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -388,6 +388,11 @@ class ScalingGroupManager(BaseManager):
         """
         Returns the launch configuration for the specified scaling group.
         """
+        key_map = {
+            "OS-DCF:diskConfig": "disk_config",
+            "flavorRef": "flavor",
+            "imageRef": "image",
+        }
         uri = "/%s/%s/launch" % (self.uri_base, utils.get_id(scaling_group))
         resp, resp_body = self.api.method_get(uri)
         ret = {}
@@ -395,15 +400,9 @@ class ScalingGroupManager(BaseManager):
         ret["type"] = data.get("type")
         args = data.get("args", {})
         ret["load_balancers"] = args.get("loadBalancers")
-        srv = args.get("server", {})
-        ret["name"] = srv.get("name")
-        ret["flavor"] = srv.get("flavorRef")
-        ret["image"] = srv.get("imageRef")
-        ret["disk_config"] = srv.get("OS-DCF:diskConfig")
-        ret["metadata"] = srv.get("metadata")
-        ret["personality"] = srv.get("personality")
-        ret["networks"] = srv.get("networks")
-        ret["key_name"] = srv.get("key_name")
+        for key, value in args.get("server", {}).items():
+            norm_key = key_map.get(key, key)
+            ret[norm_key] = value
         return ret
 
 


### PR DESCRIPTION
Recently I submitted #445 to add `config_drive` and `user_data` parameters for creating and updating autoscale launch configs.

Unfortunately I did not realize it, but `get_launch_config` was hard coded to specify what data it would return.

This pull request updates `get_launch_config` to return all server values that the API provides.

This should be backwards and forwards compatible with any additional data that can be specified in the launch config.
