### PR TITLE
Expose timestamp in StorageObjectManager::get.

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -1797,6 +1797,7 @@ class StorageObjectManager(BaseManager):
                 "content_type": hdrs.get("content-type"),
                 "hash": hdrs.get("etag"),
                 "last_modified": hdrs.get("last-modified"),
+                "timestamp": hdrs.get("x-timestamp"),
                 }
         return StorageObject(self, data, loaded=True)
 

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -1719,11 +1719,13 @@ class ObjectStorageTest(unittest.TestCase):
         conttype = utils.random_unicode()
         etag = utils.random_unicode()
         lastmod = utils.random_unicode()
+        timestamp = utils.random_unicode()
         fake_resp = fakes.FakeResponse()
         fake_resp.headers = {"content-length": contlen,
                 "content-type": conttype,
                 "etag": etag,
                 "last-modified": lastmod,
+                "x-timestamp": timestamp,
                 }
         mgr.api.method_head = Mock(return_value=(fake_resp, None))
         ret = mgr.get(obj)
@@ -1732,6 +1734,7 @@ class ObjectStorageTest(unittest.TestCase):
         self.assertEqual(ret.content_type, conttype)
         self.assertEqual(ret.hash, etag)
         self.assertEqual(ret.last_modified, lastmod)
+        self.assertEqual(ret.timestamp, timestamp)
 
     def test_sobj_mgr_get_no_length(self):
         cont = self.container


### PR DESCRIPTION
GET-ting an object returns an `x-timestamp` header, but that header is discarded by `StorageObjectManager::get`. The timestamp more precision than the `last_modified` header, and is helpful for building the key of a file after it's pushed to a versioning container (if versioning is enabled). This PR adds the timestamp header to the `StorageObject`.
