### PR TITLE
Fix CloudMonitorCheck.get

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -122,7 +122,10 @@ class CloudMonitorEntity(BaseResource):
         This isn't very efficient: it loads the entire list then filters on
         the Python side.
         """
-        return self._check_manager.find_all_checks(**kwargs)
+        checks = self._check_manager.find_all_checks(**kwargs)
+        for check in checks:
+            check.set_entity(self)
+        return checks
 
 
     def create_check(self, label=None, name=None, check_type=None,
@@ -742,7 +745,7 @@ class CloudMonitorCheck(BaseResource):
 
     def get(self):
         """Reloads the check with its current values."""
-        new = self.manager.get_check(self.entity, self)
+        new = self.manager.get(self)
         if new:
             self._add_details(new._info)
 

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -169,6 +169,13 @@ class CloudMonitoringTest(unittest.TestCase):
         ent.label = utils.random_unicode()
         self.assertEqual(ent.label, ent.name)
 
+    def test_entity_find_all_checks(self):
+        ent = self.entity
+        ent._check_manager.find_all_checks = Mock(
+            return_value=[fakes.FakeCloudMonitorCheck()])
+        checks = ent.find_all_checks()
+        self.assertEqual(checks[0].entity, ent)
+
     @patch("pyrax.manager.BaseManager.list")
     def test_pagination_mgr_list(self, mock_list):
         pm = _PaginationManager(self.client)
@@ -755,7 +762,7 @@ class CloudMonitoringTest(unittest.TestCase):
         clt = self.client
         mgr = clt._entity_manager
         id_ = utils.random_unicode()
-        chk = CloudMonitorCheck(mgr, info={"id": id_}, entity=ent)
+        chk = fakes.FakeCloudMonitorCheck(info={"id": id_}, entity=ent)
         info = chk._info
         mgr.get_check = Mock(return_value=chk)
         chk.reload()


### PR DESCRIPTION
Fix `CloudMonitorCheck.get` so that it properly calls `CloudMonitorCheckManager.get` instead of the non-existent `CloudMonitorCheckManager.get_check`.

Catch AttributeErrors raise during calls to get() from `BaseResource.__getattr__` and re-raise them as non-AttributeError to avoid implying that the Resource doesn't have the attribute just because some other attribute reference in the get() wasn't found.

`CloudMonitorEntity.list_checks` now calls `set_entity(self)` on each returned check. 
