### PR TITLE
Corrects record update API for CloudDNSManager and CloudDNSDomain

### DIFF
--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -240,7 +240,7 @@ class CloudDNSDomain(BaseResource):
                 "comment": comment,
                 }
         utils.params_to_dict(pdict, rdict)
-        return self.manager.update_records(self, rdict)
+        return self.manager.update_records(self, [rdict])
 
 
     def update_records(self, records):
@@ -875,8 +875,11 @@ class CloudDNSManager(BaseManager):
         """
         Modifies an existing record for a domain.
         """
+        if not isinstance(records, list):
+            raise TypeError("Expected records of type list")
         uri = "/domains/%s/records" % utils.get_id(domain)
-        resp, resp_body = self._async_call(uri, method="PUT", body=records,
+        resp, resp_body = self._async_call(uri, method="PUT",
+                body={"records": records},
                 error_class=exc.DomainRecordUpdateFailed, has_response=False)
         return resp_body
 

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -659,7 +659,7 @@ class CloudDNSTest(unittest.TestCase):
         req_body = {"id": rec_id, "name": nm, "data": data, "ttl": ttl}
         clt.update_record(dom, rec, data=data, ttl=ttl)
         mgr._async_call.assert_called_once_with(uri, method="PUT",
-                body=req_body, error_class=exc.DomainRecordUpdateFailed,
+                body={"records": [req_body]}, error_class=exc.DomainRecordUpdateFailed,
                 has_response=False)
 
     def test_delete_record(self):


### PR DESCRIPTION
Continuation of #455 .
- Update failing unitest
- Made against working branch

---

CloudDNSDomain.update_record calls to CloudDNSManager.update_records. update_records did not produce the correct JSON format.

See the example request at http://docs.rackspace.com/cdns/api/v1.0/cdns-devguide/content/PUT_updateRecords_v1.0__account__domains__domainId__records_records.html

This patch corrects that and ensures that that records paramater passed to CloudDNSManager.update_records is a list.
