### PR TITLE
Support creating bootable volumes

### DIFF
--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -246,7 +246,7 @@ class CloudBlockStorageManager(BaseManager):
     """
     def _create_body(self, name, size=None, volume_type=None, description=None,
              metadata=None, snapshot_id=None, clone_id=None,
-             availability_zone=None):
+             availability_zone=None, image=None):
         """
         Used to create the dict required to create a new volume
         """
@@ -260,6 +260,8 @@ class CloudBlockStorageManager(BaseManager):
             description = ""
         if metadata is None:
             metadata = {}
+        if image is not None:
+            image = utils.get_id(image)
         body = {"volume": {
                 "size": size,
                 "snapshot_id": snapshot_id,
@@ -269,6 +271,7 @@ class CloudBlockStorageManager(BaseManager):
                 "volume_type": volume_type,
                 "metadata": metadata,
                 "availability_zone": availability_zone,
+                "imageRef": image,
                 }}
         return body
 

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -274,6 +274,7 @@ class CloudBlockStorageTest(unittest.TestCase):
                 "volume_type": "SATA",
                 "metadata": {},
                 "availability_zone": availability_zone,
+                "imageRef": None,
                 }}
         ret = mgr._create_body(name=name, size=size, volume_type=volume_type,
                 description=display_description, metadata=metadata,
@@ -300,6 +301,7 @@ class CloudBlockStorageTest(unittest.TestCase):
                 "volume_type": volume_type,
                 "metadata": metadata,
                 "availability_zone": availability_zone,
+                "imageRef": None,
                 }}
         ret = mgr._create_body(name=name, size=size, volume_type=volume_type,
                 description=display_description, metadata=metadata,


### PR DESCRIPTION
Boot from volume functionality requires specifying an `imageRef` which is the image id to use in creating a bootable volume.

This pull request adds an extra kwarg to `_create_body` called `image` that can accept an image id or image object.
