### PR TITLE
Remove references to Ed's email address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,4 @@ after_success:
     coveralls
 
 notifications:
-  email:
-    - ed.leafe@rackspace.com
   irc: "irc.freenode.org#rackspace-dev"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     version=version,
     description="Python language bindings for OpenStack Clouds.",
     author="Rackspace",
-    author_email="ed.leafe@rackspace.com",
+    author_email="sdk-support@rackspace.com",
     url="https://github.com/rackspace/pyrax",
     keywords="pyrax rackspace cloud openstack",
     classifiers=[


### PR DESCRIPTION
This pull request removes the email notification from `.travis.yml` and switches the `author_email` in `setup.py` to `sdk-support`.
