### PR TITLE
exceptions: Make ClientException and its subclasses pickleable

### DIFF
--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -376,6 +376,10 @@ class ClientException(PyraxException):
             formatted_string += " (Request-ID: %s)" % self.request_id
         return formatted_string
 
+    def __reduce__(self):
+        return (self.__class__, (self.code, self.message,
+                                 self.details, self.request_id))
+
 
 class BadRequest(ClientException):
     """

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -43,6 +43,19 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(ret.details, "fake_details")
         self.assertTrue("HTTP 666" in str(ret))
 
+    def test_pickle(self):
+        error = exc.NotFound(42, 'message', 'details', 0xDEADBEEF)
+
+        import pickle
+        pickled_error = pickle.dumps(error, -1)
+
+        unpickled_error = pickle.loads(pickled_error)
+
+        self.assertIsInstance(unpickled_error, exc.NotFound)
+        self.assertEqual(unpickled_error.code, 42)
+        self.assertEqual(unpickled_error.message, 'message')
+        self.assertEqual(unpickled_error.details, 'details')
+        self.assertEqual(unpickled_error.request_id, 0xDEADBEEF)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ClientException and its subclasses is unpickleable, which can cause hard to debug crashes. For example, current celery crashes when a worker raises an instance of any pyrax exception.
