### PR TITLE
Add __version__ since a lot of people expect to be here

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -53,6 +53,7 @@ try:
     from . import exceptions as exc
     from . import http
     from . import version
+    __version__ = version.version
 
     from novaclient import exceptions as _cs_exceptions
     from novaclient import auth_plugin as _cs_auth_plugin


### PR DESCRIPTION
This PR adds a `__version__` to `__init__.py` where many people expect the version string to be accessible at.  It does not remove `pyrax.version.version` in an effort to maintain compatibility
