### PR TITLE
get_metadata in object_storage should always allow specifying prefix

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -658,11 +658,11 @@ class Container(BaseResource):
                 key=key, cached=cached)
 
 
-    def get_object_metadata(self, obj):
+    def get_object_metadata(self, obj, prefix=None):
         """
         Returns the metadata for the specified object as a dict.
         """
-        return self.object_manager.get_metadata(obj)
+        return self.object_manager.get_metadata(obj, prefix)
 
 
     def set_object_metadata(self, obj, metadata, clear=False, extra_info=None,
@@ -1677,11 +1677,11 @@ class StorageObject(BaseResource):
         return self.manager.purge(self, email_addresses=email_addresses)
 
 
-    def get_metadata(self):
+    def get_metadata(self, prefix=None):
         """
         Returns the metadata for this object as a dict.
         """
-        return self.manager.get_metadata(self)
+        return self.manager.get_metadata(self, prefix)
 
 
     def set_metadata(self, metadata, clear=False, prefix=None):

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -622,7 +622,7 @@ class ObjectStorageTest(unittest.TestCase):
         cont.object_manager.get_metadata = Mock()
         obj = utils.random_unicode()
         cont.get_object_metadata(obj)
-        cont.object_manager.get_metadata.assert_called_once_with(obj)
+        cont.object_manager.get_metadata.assert_called_once_with(obj, None)
 
     def test_cont_set_object_metadata(self):
         cont = self.container
@@ -1607,7 +1607,7 @@ class ObjectStorageTest(unittest.TestCase):
         mgr = obj.manager
         mgr.get_metadata = Mock()
         obj.get_metadata()
-        mgr.get_metadata.assert_called_once_with(obj)
+        mgr.get_metadata.assert_called_once_with(obj, None)
 
     def test_sobj_set_metadata(self):
         obj = self.obj


### PR DESCRIPTION
This PR ensures that all `get_metadata` calls in `object_storage` can be passed a `prefix` arg.
