### PR TITLE
Support body.keys() when it returns an iterable instead of a list (Python 3). Fixes #476.

### DIFF
--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -478,7 +478,8 @@ def from_response(response, body):
             message = body.get("message")
             details = body.get("details")
             if message is details is None:
-                error = body[body.keys()[0]]
+                first_key = next(iter(body.keys()))
+                error = body[first_key]
                 if isinstance(error, dict):
                     message = error.get("message", None)
                     details = error.get("details", None)


### PR DESCRIPTION
I believe this approach is sound. It will raise a StopIteration instead of a KeyError if `keys()` is empty, but I suspect the actual exception in that case is not important. If it's important to keep that behavior, an alternative approach would be to cast the result of `keys()` to a list before dereferencing the first element.
