### PR TITLE
Add prefix kwarg to a few remaining get_metadata functions

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -1523,11 +1523,11 @@ class ContainerManager(BaseManager):
 
 
     @assure_container
-    def get_object_metadata(self, container, obj):
+    def get_object_metadata(self, container, obj, prefix=None):
         """
         Returns the metadata for the specified object as a dict.
         """
-        return container.get_object_metadata(obj)
+        return container.get_object_metadata(obj, prefix=prefix)
 
 
     @assure_container
@@ -2588,11 +2588,11 @@ class StorageClient(BaseClient):
         return self._manager.set_cdn_metadata(container, metadata)
 
 
-    def get_object_metadata(self, container, obj):
+    def get_object_metadata(self, container, obj, prefix=None):
         """
         Returns the metadata for the specified object as a dict.
         """
-        return self._manager.get_object_metadata(container, obj)
+        return self._manager.get_object_metadata(container, obj, prefix=prefix)
 
 
     def set_object_metadata(self, container, obj, metadata, clear=False,

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -1479,7 +1479,7 @@ class ObjectStorageTest(unittest.TestCase):
         obj = utils.random_unicode()
         cont.get_object_metadata = Mock()
         mgr.get_object_metadata(cont, obj)
-        cont.get_object_metadata.assert_called_once_with(obj)
+        cont.get_object_metadata.assert_called_once_with(obj, prefix=None)
 
     def test_cmgr_set_object_metadata(self):
         cont = self.container
@@ -2707,7 +2707,7 @@ class ObjectStorageTest(unittest.TestCase):
         obj = self.obj
         mgr.get_object_metadata = Mock()
         clt.get_object_metadata(cont, obj)
-        mgr.get_object_metadata.assert_called_once_with(cont, obj)
+        mgr.get_object_metadata.assert_called_once_with(cont, obj, prefix=None)
 
     def test_clt_set_object_metadata(self):
         clt = self.client


### PR DESCRIPTION
This PR adds the prefix kwarg to a few remaining object get_metadata functions
