### PR TITLE
Match requirements to spec and travis.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,10 @@ class sdist(_sdist):
         # Run parent constructor
         _sdist.run(self)
 
-testing_requires = ["mock"]
+testing_requires = [
+    "mock",
+    "nose",
+]
 
 setup(
     name="pyrax",
@@ -73,11 +76,13 @@ setup(
     ],
     install_requires=[
         "python-novaclient>=2.13.0",
+        "python-swiftclient>=1.5.0",
         "rackspace-novaclient",
         "keyring",
         "requests>=2.2.1",
         "six>=1.5.2",
-    ] + testing_requires,
+    ],
+    tests_require = testing_requires,
     packages=[
         "pyrax",
         "pyrax/identity",


### PR DESCRIPTION
Looks like python-swiftclient was in the spec but not in the
install_requires.  I've also added nose to the testing requirements and
use the proper tests_require parameter (which may be dropped due to
ancient distutils requirements).

Would it be possible to use extras_require for bringing in the rackspace
items (to again match the spec)?
