### PR TITLE
Added the ability to specify database instance type (datastore).

### DIFF
--- a/pyrax/clouddatabases.py
+++ b/pyrax/clouddatabases.py
@@ -82,7 +82,7 @@ class CloudDatabaseManager(BaseManager):
 
 
     def _create_body(self, name, flavor=None, volume=None, databases=None,
-            users=None):
+            users=None, datastore=None):
         """
         Used to create the dict required to create a Cloud Database instance.
         """
@@ -95,12 +95,16 @@ class CloudDatabaseManager(BaseManager):
             databases = []
         if users is None:
             users = []
+        if datastore is None:
+            datastore = {"version": "5.1",
+              "type": "MySQL"}
         body = {"instance": {
                 "name": name,
                 "flavorRef": flavor_ref,
                 "volume": {"size": volume},
                 "databases": databases,
                 "users": users,
+                "datastore": datastore
                 }}
         return body
 

--- a/tests/unit/test_cloud_databases.py
+++ b/tests/unit/test_cloud_databases.py
@@ -892,7 +892,9 @@ class CloudDatabasesTest(unittest.TestCase):
                 "flavorRef": example_uri,
                 "volume": {"size": 1},
                 "databases": [],
-                "users": []}}
+                "users": [],
+                "datastore": {"version": "5.1",
+              "type": "MySQL"}}}
         self.assertEqual(ret, expected)
 
 


### PR DESCRIPTION
I added the ability to specify what kind of datastore you want the instance to be.  I made the default mysql 5.1 as it is available in every region.
