### PR TITLE
Add marker and limit params for listing database backups

### DIFF
--- a/pyrax/clouddatabases.py
+++ b/pyrax/clouddatabases.py
@@ -139,20 +139,24 @@ class CloudDatabaseManager(BaseManager):
         return CloudDatabaseInstance(self, resp_body.get("instance", {}))
 
 
-    def list_backups(self, instance=None):
+    def list_backups(self, instance=None, marker=0, limit=20):
         """
-        Returns a list of all backups by default, or just for a particular
+        Returns a paginated list of backups, or just for a particular
         instance.
         """
-        return self.api._backup_manager.list(instance=instance)
+        return self.api._backup_manager.list(instance=instance, limit=limit,
+                                             marker=marker)
 
 
-    def _list_backups_for_instance(self, instance):
+    def _list_backups_for_instance(self, instance, marker=0, limit=20):
         """
         Instance-specific backups are handled through the instance manager,
         not the backup manager.
         """
-        uri = "/%s/%s/backups" % (self.uri_base, utils.get_id(instance))
+        uri = "/%s/%s/backups?limit=%d&marker=%d" % (self.uri_base,
+                                                     utils.get_id(instance),
+                                                     int(limit),
+                                                     int(marker))
         resp, resp_body = self.api.method_get(uri)
         mgr = self.api._backup_manager
         return [CloudDatabaseBackup(mgr, backup)
@@ -314,14 +318,15 @@ class CloudDatabaseBackupManager(BaseManager):
         return body
 
 
-    def list(self, instance=None):
+    def list(self, instance=None, limit=20, marker=0):
         """
-        Return a list of all backups by default, or just for a particular
+        Return a paginated list of backups, or just for a particular
         instance.
         """
         if instance is None:
             return super(CloudDatabaseBackupManager, self).list()
-        return self.api._manager._list_backups_for_instance(instance)
+        return self.api._manager._list_backups_for_instance(instance, limit=limit,
+                                                            marker=marker)
 
 
 
@@ -534,11 +539,12 @@ class CloudDatabaseInstance(BaseResource):
         self.manager.action(self, "resize", body=body)
 
 
-    def list_backups(self):
+    def list_backups(self, limit=20, marker=0):
         """
-        Returns a list of all backups for this instance.
+        Returns a paginated list of backups for this instance.
         """
-        return self.manager._list_backups_for_instance(self)
+        return self.manager._list_backups_for_instance(self, limit=limit,
+                                                       marker=marker)
 
 
     def create_backup(self, name, description=None):
@@ -871,12 +877,13 @@ class CloudDatabaseClient(BaseClient):
         return href
 
 
-    def list_backups(self, instance=None):
+    def list_backups(self, instance=None, limit=20, marker=0):
         """
-        Returns a list of all backups by default, or just for a particular
+        Returns a paginated list of backups by default, or just for a particular
         instance.
         """
-        return self._backup_manager.list(instance=instance)
+        return self._backup_manager.list(instance=instance, limit=limit,
+                                         marker=marker)
 
 
     def get_backup(self, backup):

--- a/tests/unit/test_cloud_databases.py
+++ b/tests/unit/test_cloud_databases.py
@@ -141,13 +141,14 @@ class CloudDatabasesTest(unittest.TestCase):
         mgr = inst.manager
         mgr.api._backup_manager.list = Mock(return_value=(None, None))
         mgr.list_backups(inst)
-        mgr.api._backup_manager.list.assert_called_once_with(instance=inst)
+        mgr.api._backup_manager.list.assert_called_once_with(instance=inst,
+                limit=20, marker=0)
 
     def test_mgr_list_backups_for_instance(self):
         inst = self.instance
         mgr = inst.manager
         mgr.api.method_get = Mock(return_value=(None, {"backups": []}))
-        expected_uri = "/%s/%s/backups" % (mgr.uri_base, inst.id)
+        expected_uri = "/%s/%s/backups?limit=20&marker=0" % (mgr.uri_base, inst.id)
         mgr._list_backups_for_instance(inst)
         mgr.api.method_get.assert_called_once_with(expected_uri)
 
@@ -279,7 +280,8 @@ class CloudDatabasesTest(unittest.TestCase):
         mgr = inst.manager
         mgr._list_backups_for_instance = Mock()
         inst.list_backups()
-        mgr._list_backups_for_instance.assert_called_once_with(inst)
+        mgr._list_backups_for_instance.assert_called_once_with(inst, limit=20,
+                marker=0)
 
     def test_inst_create_backup(self):
         inst = self.instance
@@ -579,7 +581,8 @@ class CloudDatabasesTest(unittest.TestCase):
         db_mgr = mgr.api._manager
         db_mgr._list_backups_for_instance = Mock()
         bu_mgr.list(instance=inst)
-        db_mgr._list_backups_for_instance.assert_called_once_with(inst)
+        db_mgr._list_backups_for_instance.assert_called_once_with(inst, limit=20,
+                marker=0)
 
     def test_clt_change_user_password(self):
         clt = self.client
@@ -792,7 +795,7 @@ class CloudDatabasesTest(unittest.TestCase):
         mgr = clt._backup_manager
         mgr.list = Mock()
         clt.list_backups()
-        mgr.list.assert_called_once_with(instance=None)
+        mgr.list.assert_called_once_with(instance=None, limit=20, marker=0)
 
     def test_clt_list_backups_for_instance(self):
         clt = self.client
@@ -800,7 +803,7 @@ class CloudDatabasesTest(unittest.TestCase):
         mgr.list = Mock()
         inst = utils.random_unicode()
         clt.list_backups(instance=inst)
-        mgr.list.assert_called_once_with(instance=inst)
+        mgr.list.assert_called_once_with(instance=inst, limit=20, marker=0)
 
     def test_clt_get_backup(self):
         clt = self.client


### PR DESCRIPTION
This PR adds `limit` and `marker` kwargs for listing database backups.

This does not currently implement `pyrax.utils.ResultsIterator` to enable automatic paginated retrieval, but is a start that would at least allow people to retrieve all backups.

Fixes #495
