### PR TITLE
Also catch AttributeError since it is possible to not get back JSON data. Fixes #457

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -605,13 +605,13 @@ class BaseIdentity(object):
             # Internal Server Error
             try:
                 error_msg = resp_body[list(resp_body.keys())[0]]["message"]
-            except KeyError:
+            except (KeyError, AttributeError):
                 error_msg = "Service Currently Unavailable"
             raise exc.InternalServerError(error_msg)
         elif resp.status_code > 299:
             try:
                 msg = resp_body[list(resp_body.keys())[0]]["message"]
-            except KeyError:
+            except (KeyError, AttributeError):
                 msg = None
             if msg:
                 err = "%s - %s." % (resp.reason, msg)


### PR DESCRIPTION
This PR also catches AttributeError for those times when JSON data is not returned from the API.

Fixes #457 
