### PR TITLE
Update CloudMonitorClient to use assure_entity instead of using self._entity_manager

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -1249,26 +1249,24 @@ class CloudMonitorClient(BaseClient):
         """
         return self._notification_plan_manager.delete(notification_plan)
 
-
+    @assure_entity
     def create_alarm(self, entity, check, notification_plan, criteria=None,
             disabled=False, label=None, name=None, metadata=None):
         """
         Creates an alarm that binds the check on the given entity with a
         notification plan.
         """
-        return self._entity_manager.create_alarm(entity, check,
-            notification_plan, criteria=criteria, disabled=disabled,
-            label=label, name=name, metadata=metadata)
+        return entity.create_alarm(check, notification_plan, criteria=criteria,
+            disabled=disabled, label=label, name=name, metadata=metadata)
 
-
+    @assure_entity
     def update_alarm(self, entity, alarm, criteria=None, disabled=False,
             label=None, name=None, metadata=None):
         """
         Updates an existing alarm on the given entity.
         """
-        return self._entity_manager.update_alarm(entity, alarm,
-                criteria=criteria, disabled=disabled, label=label, name=name,
-                metadata=metadata)
+        return entity.update_alarm(alarm, criteria=criteria, disabled=disabled,
+            label=label, name=name, metadata=metadata)
 
 
     @assure_entity
@@ -1280,18 +1278,20 @@ class CloudMonitorClient(BaseClient):
                 return_next=return_next)
 
 
+    @assure_entity
     def get_alarm(self, entity, alarm_id):
         """
         Returns the alarm with the specified ID for the entity.
         """
-        return self._entity_manager.get_alarm(entity, alarm_id)
+        return entity.get_alarm(alarm_id)
 
 
+    @assure_entity
     def delete_alarm(self, entity, alarm):
         """
         Deletes the specified alarm.
         """
-        return self._entity_manager.delete_alarm(entity, alarm)
+        return entity.delete_alarm(alarm)
 
 
     def list_notification_types(self):

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -1350,9 +1350,9 @@ class CloudMonitoringTest(unittest.TestCase):
         mgr = clt._entity_manager
         answer = utils.random_unicode()
         alm = utils.random_unicode()
-        mgr.get_alarm = Mock(return_value=answer)
+        ent.get_alarm = Mock(return_value=answer)
         ret = clt.get_alarm(ent, alm)
-        mgr.get_alarm.assert_called_once_with(ent, alm)
+        ent.get_alarm.assert_called_once_with(alm)
         self.assertEqual(ret, answer)
 
     def test_clt_create_alarm(self):
@@ -1367,10 +1367,10 @@ class CloudMonitoringTest(unittest.TestCase):
         name = utils.random_unicode()
         metadata = utils.random_unicode()
         answer = utils.random_unicode()
-        mgr.create_alarm = Mock(return_value=answer)
+        ent.create_alarm = Mock(return_value=answer)
         ret = clt.create_alarm(ent, chk, nplan, criteria=criteria,
                 disabled=disabled, label=label, name=name, metadata=metadata)
-        mgr.create_alarm.assert_called_once_with(ent, chk, nplan,
+        ent.create_alarm.assert_called_once_with(chk, nplan,
                 criteria=criteria, disabled=disabled, label=label, name=name,
                 metadata=metadata)
         self.assertEqual(ret, answer)
@@ -1386,10 +1386,10 @@ class CloudMonitoringTest(unittest.TestCase):
         name = utils.random_unicode()
         metadata = utils.random_unicode()
         answer = utils.random_unicode()
-        mgr.update_alarm = Mock(return_value=answer)
+        ent.update_alarm = Mock(return_value=answer)
         ret = clt.update_alarm(ent, alm, criteria=criteria, disabled=disabled,
                 label=label, name=name, metadata=metadata)
-        mgr.update_alarm.assert_called_once_with(ent, alm, criteria=criteria,
+        ent.update_alarm.assert_called_once_with(alm, criteria=criteria,
                 disabled=disabled, label=label, name=name, metadata=metadata)
         self.assertEqual(ret, answer)
 
@@ -1398,9 +1398,9 @@ class CloudMonitoringTest(unittest.TestCase):
         ent = self.entity
         mgr = clt._entity_manager
         alm = utils.random_unicode()
-        mgr.delete_alarm = Mock()
+        ent.delete_alarm = Mock()
         clt.delete_alarm(ent, alm)
-        mgr.delete_alarm.assert_called_once_with(ent, alm)
+        ent.delete_alarm.assert_called_once_with(alm)
 
     def test_clt_list_notification_types(self):
         clt = self.client


### PR DESCRIPTION
Utilize assure_entity to allow operating on the entity directly instead of attempting to use self._entity_manager.

Fixes #468
