### PR TITLE
BaseIdentity._call should respect BaseIdentity.verify_ssl

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -566,7 +566,7 @@ class BaseIdentity(object):
         if "tokens" in uri:
             # We'll handle the exception here
             kwargs["raise_exception"] = False
-        return pyrax.http.request(mthd, uri, **kwargs)
+        return pyrax.http.request(mthd, uri, verify=self.verify_ssl, **kwargs)
 
 
     def authenticate(self, username=None, password=None, api_key=None,

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -886,8 +886,8 @@ class IdentityTest(unittest.TestCase):
             for admin in (True, False):
                 ident.method_post(uri, data=data, headers=headers,
                         std_headers=std_headers, admin=admin)
-                pyrax.http.request.assert_called_with("POST", uri, body=data,
-                        headers=expected_headers)
+                pyrax.http.request.assert_called_with("POST", uri, verify=True,
+                        body=data, headers=expected_headers)
                 self.assertEqual(out.getvalue(), "")
                 out.seek(0)
                 out.truncate()
@@ -904,7 +904,7 @@ class IdentityTest(unittest.TestCase):
         pyrax.http.request = Mock()
         ident._call("POST", "tokens", False, {}, {}, False)
         pyrax.http.request.assert_called_with("POST",
-                "http://example.com/v2.0/tokens", headers={},
+                "http://example.com/v2.0/tokens", verify=False, headers={},
                 raise_exception=False)
 
     def test_call_with_slash(self):
@@ -915,7 +915,7 @@ class IdentityTest(unittest.TestCase):
         pyrax.http.request = Mock()
         ident._call("POST", "tokens", False, {}, {}, False)
         pyrax.http.request.assert_called_with("POST",
-                "http://example.com/v2.0/tokens", headers={},
+                "http://example.com/v2.0/tokens", verify=False, headers={},
                 raise_exception=False)
 
     def test_list_users(self):


### PR DESCRIPTION
Although `verify_ssl` is set on the identity instance, it is never utilized by `_call`
