### PR TITLE
WIP: Add client to talk to RackConnect api

### DIFF
--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -422,6 +422,16 @@ class NoUniqueMatch(ClientException):
     message = "Not Unique"
 
 
+class Conflict(ClientException):
+    """
+    HTTP 409 - Conflict
+    """
+    def __init__(self, message, *args, **kwargs):
+        code = 409
+        message = message or "Conflict"
+        super(Conflict, self).__init__(code, message, *args, **kwargs)
+
+
 class OverLimit(ClientException):
     """
     HTTP 413 - Over limit: you're over the API limits for this time period.

--- a/pyrax/rackconnect.py
+++ b/pyrax/rackconnect.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2014 Rackspace US, Inc.
+
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import os
+
+from pyrax.client import BaseClient
+import pyrax.exceptions as exc
+from pyrax.manager import BaseManager
+from pyrax.resource import BaseResource
+import pyrax.utils as utils
+
+
+class RackConnect(BaseResource):
+    """Represents an instance of a RackConnect resource."""
+    pass
+
+
+class RackConnectManager(BaseManager):
+    """Does nothing special, but is used in testing."""
+    pass
+
+
+class RackConnectClient(BaseClient):
+    """A client to interact with RackConnected resources."""
+
+    name = "RackConnect v3 Resources"
+
+    def __init__(self, *args, **kwargs):
+        self.tenant_id = os.environ.get('OS_TENANT_NAME', None)  # FIXME
+
+    def get(self):
+        """Fetch information from the rackconnected resource.
+
+        Use the api to fetch information about the resource. You might
+        need to refactor this stuff to conform to pyrax architecture later,
+        but start simple.
+        """
+        raise NotImplementedError
+
+    def create_pool_member(self, pool_id, server_id):
+        """Add the given nodes to the pool.
+
+        :param pool_id: id of the load balancer pool.
+        :param server_id: id of server that will be added to the pool.
+
+        """
+        body = []
+
+        # construct the body of the request
+
+        body = json.dumps({
+            'cloud_server': {
+                'id': server_id,
+            },
+            'load_balancer_pool': {
+                'id': pool_id,
+                }
+        })
+
+        uri = '/v3/%s/load_balancer_pools/nodes' % self.tenant_id
+
+        # hit the api
+
+        resp, resp_body = self.method_post(uri=uri, body=body)
+
+        if resp.status_code == 201:
+            return resp_body
+        elif resp.status_code == 409:
+            raise exc.Conflict(resp_body)
+        else:
+            raise exc.ClientException(code=resp.status_code, message=resp_body)
+
+    def delete_pool_members(self, nodes):
+        """Delete all the nodes specified.
+
+        :param nodes: a list of ids of nodes to be removed.
+
+        #TODO: should nodes be objects, each of which manage a rackconnected
+        load balancer? Or should I continue to refer to the nodes by their
+        ids? It seems like what Im asking is: should I write a manager class
+        for the nodes that are created.
+        """
+        raise NotImplementedError

--- a/tests/unit/test_rackconnect.py
+++ b/tests/unit/test_rackconnect.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2014 Rackspace US, Inc.
+
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import unittest
+
+import mock
+
+import pyrax.exceptions as exc
+from pyrax.rackconnect import RackConnect
+from pyrax.rackconnect import RackConnectClient
+from pyrax.rackconnect import RackConnectManager
+
+
+class RackConnectTest(unittest.TestCase):
+    """Unit test for rackconnect resources."""
+
+    def setUp(self):
+        self.client = mock.Mock()
+
+    def test_create_pool_member(self):
+
+        rc_client = RackConnectClient()
+        rc_client.tenant_id = "d6d3aa7c-dfa5-4e61-96ee-f8433840cff2"
+        rc_client.method_post = mock.Mock()
+        pool_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        server_id = "d95ae0c4-6ab8-4873-b82f-f8433840cff2"
+        req_body = json.dumps({
+            "cloud_server": {
+                "id": server_id
+                }
+            })
+
+        # test for different responses
+        mock_resp = mock.Mock()
+        mock_resp.status_code = 201
+        mock_resp_body = {
+            "created": "2014-05-30T03:23:42Z",
+            "cloud_server": {
+                "id": "d95ae0c4-6ab8-4873-b82f-f8433840cff2"
+            },
+            "id": "1860451d-fb89-45b8-b54e-151afceb50e5",
+            "load_balancer_pool": {
+                "id": "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+            },
+            "status": "ADDING",
+            "status_detail": None,
+            "updated": None,
+        }
+
+        rc_client.method_post.return_value = (mock_resp, mock_resp_body)
+
+        resp = rc_client.create_pool_member(pool_id, server_id)
+
+        expected_resp = {
+            "created": "2014-05-30T03:23:42Z",
+            "cloud_server": {
+                "id": "d95ae0c4-6ab8-4873-b82f-f8433840cff2"
+            },
+            "id": "1860451d-fb89-45b8-b54e-151afceb50e5",
+            "load_balancer_pool": {
+                "id": "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+            },
+            "status": "ADDING",
+            "status_detail": None,
+            "updated": None,
+        }
+
+        self.assertEqual(resp, expected_resp)
+
+        mock_resp.status_code = 409
+        mock_resp_body = ("Cloud Server d95ae0c4-6ab8-4873-b82f-f8433840cff2 "
+                          "does not exist")
+
+        with self.assertRaises(exc.Conflict):
+            resp = rc_client.create_pool_member(pool_id, server_id)
+
+    def tearDown(self):
+        self.client = None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
=== DO NOT MERGE ===
This patch adds a simple client to talk with the rackconnect api.
Currently, it only deals with adding/removing dedicated
loadbalancers and assigning/removing public IP's to
cloudservers.
