### PR TITLE
Respect the configured auth_endpoint in KeystoneIdentity

### DIFF
--- a/pyrax/identity/keystone_identity.py
+++ b/pyrax/identity/keystone_identity.py
@@ -18,7 +18,7 @@ class KeystoneIdentity(BaseIdentity):
     _default_region = "RegionOne"
 
     def _get_auth_endpoint(self):
-        ep = pyrax.get_setting("auth_endpoint")
+        ep = self._auth_endpoint or pyrax.get_setting("auth_endpoint")
         if ep is None:
             raise exc.EndpointNotDefined("No auth endpoint has been specified.")
         return ep


### PR DESCRIPTION
Updates `_get_auth_endpoint` to respect the configured `auth_endpoint`/`_auth_endpoint`
