### PR TITLE
verify_ssl should be properly passed down when creating a context

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -645,7 +645,7 @@ def _get_service_endpoint(context, svc, region=None, public=True):
     return ep
 
 
-def connect_to_cloudservers(region=None, context=None, **kwargs):
+def connect_to_cloudservers(region=None, context=None, verify_ssl=None, **kwargs):
     """Creates a client for working with cloud servers."""
     context = context or identity
     _cs_auth_plugin.discover_auth_systems()
@@ -660,7 +660,10 @@ def connect_to_cloudservers(region=None, context=None, **kwargs):
     if not mgt_url:
         # Service is not available
         return
-    insecure = not get_setting("verify_ssl")
+    if verify_ssl is None:
+        insecure = not get_setting("verify_ssl")
+    else:
+        insecure = not verify_ssl
     cs_shell = _cs_shell()
     extensions = cs_shell._discover_extensions("1.1")
     cloudservers = _cs_client.Client(context.username, context.password,
@@ -728,13 +731,14 @@ def connect_to_cloudfiles(region=None, public=None):
 
 
 @_require_auth
-def _create_client(ep_name, region, public=True):
+def _create_client(ep_name, region, public=True, verify_ssl=None):
     region = _safe_region(region)
     ep = _get_service_endpoint(None, ep_name.split(":")[0], region,
             public=public)
     if not ep:
         return
-    verify_ssl = get_setting("verify_ssl")
+    if verify_ssl is None:
+        verify_ssl = get_setting("verify_ssl")
     cls = _client_classes[ep_name]
     client = cls(identity, region_name=region, management_url=ep,
             verify_ssl=verify_ssl, http_log_debug=_http_debug)

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -259,7 +259,7 @@ class IdentityTest(unittest.TestCase):
         ret = ep._create_client(None, None, public)
         self.assertEqual(ret, fake_client)
         pyrax.connect_to_cloudservers.assert_called_once_with(region=ep.region,
-                context=ep.identity)
+                context=ep.identity, verify_ssl=True)
         pyrax.connect_to_cloudservers = sav_conn
         pyrax.get_setting = sav_gs
 


### PR DESCRIPTION
Currently when using `create_context` the `verify_ssl` argument doesn't get passed down properly to the clients  of the context.  This change resolves that.
