### PR TITLE
Make library Python 2 and 3 compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ all: rpms
 clean:
 	rm -rf dist/ build/ rpm-build/ rpms/
 	rm -rf docs/*.gz MANIFEST *~
+	rm -rf .tox/
 	find . -name '*.pyc' -exec rm -f {} \;
+	find . -name '__pycache__' -exec rm -rf {} \; -prune
 
 build: clean
 	python setup.py build -f

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
 * Cloud Backups
 * Add Cloud Files container sync
 * Add support for Cloud Networks virtual interfaces
-
-* Python 3 compatibilty

--- a/docs/cloud_files.md
+++ b/docs/cloud_files.md
@@ -445,6 +445,17 @@ Metadata for storage objects works exactly the same, using the analogous methods
 Cloud Files makes it easy to publish your stored objects over the high-speed Akamai CDN. Content is made available at the container level. Individual files within a public container cannot be private. This may affect your storage design, so that only files you wish to have accessible to the public are stored in public containers.
 
 
+### CDN default web pages
+
+You can set a static web page as the landing page for you CND-enabled containter by calling:
+
+    cont.set_web_index_page("example-index.html")
+
+Set the header indicating the error page in this container by calling:
+
+    cont.set_web_error_page("example-error.html")
+
+
 ### Publishing a Container to CDN
 To publish a container to CDN, simply make the following call:
 

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -645,7 +645,7 @@ def _get_service_endpoint(context, svc, region=None, public=True):
     return ep
 
 
-def connect_to_cloudservers(region=None, context=None, **kwargs):
+def connect_to_cloudservers(region=None, context=None, verify_ssl=None, **kwargs):
     """Creates a client for working with cloud servers."""
     context = context or identity
     _cs_auth_plugin.discover_auth_systems()
@@ -660,7 +660,10 @@ def connect_to_cloudservers(region=None, context=None, **kwargs):
     if not mgt_url:
         # Service is not available
         return
-    insecure = not get_setting("verify_ssl")
+    if verify_ssl is None:
+        insecure = not get_setting("verify_ssl")
+    else:
+        insecure = not verify_ssl
     cs_shell = _cs_shell()
     extensions = cs_shell._discover_extensions("1.1")
     cloudservers = _cs_client.Client(context.username, context.password,
@@ -728,13 +731,14 @@ def connect_to_cloudfiles(region=None, public=None):
 
 
 @_require_auth
-def _create_client(ep_name, region, public=True):
+def _create_client(ep_name, region, public=True, verify_ssl=None):
     region = _safe_region(region)
     ep = _get_service_endpoint(None, ep_name.split(":")[0], region,
             public=public)
     if not ep:
         return
-    verify_ssl = get_setting("verify_ssl")
+    if verify_ssl is None:
+        verify_ssl = get_setting("verify_ssl")
     cls = _client_classes[ep_name]
     client = cls(identity, region_name=region, management_url=ep,
             verify_ssl=verify_ssl, http_log_debug=_http_debug)

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -28,7 +28,7 @@ The source code for <b>pyrax</b> can be found at:
 http://github.com/rackspace/pyrax
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from functools import wraps
 import inspect
 import logging

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -192,10 +192,11 @@ class Settings(object):
                     return _import_identity(ityp)
             else:
                 env_var = self.env_dct.get(key)
-            try:
-                ret = os.environ[env_var]
-            except KeyError:
-                ret = None
+            if env_var is not None:
+                try:
+                    ret = os.environ[env_var]
+                except KeyError:
+                    ret = None
         return ret
 
 

--- a/pyrax/autoscale.py
+++ b/pyrax/autoscale.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import base64
 

--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import six.moves.configparser as ConfigParser
 import datetime
@@ -489,7 +489,7 @@ class BaseIdentity(object):
             raise exc.AuthenticationFailed("Incorrect/unauthorized "
                     "credentials received")
         elif resp.status_code > 299:
-            msg = resp_body[resp_body.keys()[0]]["message"]
+            msg = resp_body[next(iter(resp_body))]["message"]
             raise exc.AuthenticationFailed("%s - %s." % (resp.reason, msg))
         return resp, resp_body
 

--- a/pyrax/client.py
+++ b/pyrax/client.py
@@ -22,12 +22,14 @@
 OpenStack Client interface. Handles the REST calls and responses.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import json
 import logging
 import requests
+import six
 import time
+
 from six.moves import urllib
 
 import pyrax
@@ -35,15 +37,11 @@ import pyrax.exceptions as exc
 
 
 def _safe_quote(val):
-    """
-    Unicode values will raise a KeyError, so catch those and encode in UTF-8.
-    """
-    SAFE_QUOTE_CHARS = "/.?&=,"
-    try:
-        ret = urllib.parse.quote(val, safe=SAFE_QUOTE_CHARS)
-    except KeyError:
-        ret = urllib.parse.quote(val.encode("utf-8"), safe=SAFE_QUOTE_CHARS)
-    return ret
+    # urllib.parse.quote expects bytes
+    SAFE_QUOTE_CHARS = b"/.?&=,"
+    if isinstance(val, six.text_type):
+        val = val.encode(pyrax.get_encoding())
+    return urllib.parse.quote(val, safe=SAFE_QUOTE_CHARS)
 
 
 class BaseClient(object):

--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -96,6 +96,23 @@ class CloudBlockStorageSnapshot(BaseResource):
                 super(CloudBlockStorageSnapshot, self).delete()
 
 
+    def update(self, display_name=None, display_description=None):
+        """
+        Update the specified values on this snapshot. You may specify one or
+        more values to update. If no values are specified as non-None, the call
+        is a no-op; no exception will be raised.
+        """
+        return self.manager.update(self, display_name=display_name,
+                display_description=display_description)
+
+
+    def rename(self, name):
+        """
+        Allows for direct renaming of an existing snapshot.
+        """
+        return self.update(display_name=name)
+
+
     def _get_name(self):
         return self.display_name
 
@@ -185,6 +202,23 @@ class CloudBlockStorageVolume(BaseResource):
             # Notify the user? Record it somewhere?
             # For now, just re-raise
             raise
+
+
+    def update(self, display_name=None, display_description=None):
+        """
+        Update the specified values on this volume. You may specify one or more
+        values to update. If no values are specified as non-None, the call is a
+        no-op; no exception will be raised.
+        """
+        return self.manager.update(self, display_name=display_name,
+                display_description=display_description)
+
+
+    def rename(self, name):
+        """
+        Allows for direct renaming of an existing volume.
+        """
+        return self.update(display_name=name)
 
 
     def create_snapshot(self, name=None, description=None, force=False):
@@ -294,7 +328,8 @@ class CloudBlockStorageManager(BaseManager):
     def update(self, volume, display_name=None, display_description=None):
         """
         Update the specified values on the specified volume. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
         uri = "/%s/%s" % (self.uri_base, utils.get_id(volume))
         param_dict = {}
@@ -380,7 +415,8 @@ class CloudBlockStorageSnapshotManager(BaseManager):
     def update(self, snapshot, display_name=None, display_description=None):
         """
         Update the specified values on the specified snapshot. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
         uri = "/%s/%s" % (self.uri_base, utils.get_id(snapshot))
         param_dict = {}
@@ -449,10 +485,18 @@ class CloudBlockStorageClient(BaseClient):
     def update(self, volume, display_name=None, display_description=None):
         """
         Update the specified values on the specified volume. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
-        return self._manager.update(volume, display_name=display_name,
+        return volume.update(display_name=display_name,
                 display_description=display_description)
+
+
+    def rename(self, volume, name):
+        """
+        Allows for direct renaming of an existing volume.
+        """
+        return self.update(volume, display_name=name)
 
 
     @assure_volume
@@ -480,12 +524,19 @@ class CloudBlockStorageClient(BaseClient):
         return snapshot.delete()
 
 
+    @assure_snapshot
     def update_snapshot(self, snapshot, display_name=None,
             display_description=None):
         """
         Update the specified values on the specified snapshot. You may specify
         one or more values to update.
         """
-        return self._snapshot_manager.update(snapshot,
-                display_name=display_name,
+        return snapshot.update(display_name=display_name,
                 display_description=display_description)
+
+
+    def rename_snapshot(self, snapshot, name):
+        """
+        Allows for direct renaming of an existing snapshot.
+        """
+        return self.update_snapshot(snapshot, display_name=name)

--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 import time
@@ -283,7 +284,7 @@ class CloudBlockStorageManager(BaseManager):
         """
         Used to create the dict required to create a new volume
         """
-        if not isinstance(size, (int, long)) or not (
+        if not isinstance(size, six.integer_types) or not (
                 MIN_SIZE <= size <= MAX_SIZE):
             raise exc.InvalidSize("Volume sizes must be integers between "
                     "%s and %s." % (MIN_SIZE, MAX_SIZE))

--- a/pyrax/clouddatabases.py
+++ b/pyrax/clouddatabases.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 

--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 import json

--- a/pyrax/cloudloadbalancers.py
+++ b/pyrax/cloudloadbalancers.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 

--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 import re

--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -72,8 +72,8 @@ class CloudMonitorEntity(BaseResource):
                 uri_base="entities/%s/checks" % self.id,
                 resource_class=CloudMonitorCheck, response_key=None,
                 plural_response_key=None)
-        self._alarm_manager = CloudMonitorAlarmManager(self.manager.api,
-                uri_base="entities/%s/alarms" % self.id,
+        self._alarm_manager = CloudMonitorAlarmManager(self.manager,
+                self.manager.api, uri_base="entities/%s/alarms" % self.id,
                 resource_class=CloudMonitorAlarm, response_key=None,
                 plural_response_key=None)
 
@@ -476,6 +476,15 @@ class CloudMonitorAlarmManager(_PaginationManager):
     """
     Handles all of the alarm-specific requests.
     """
+
+    def __init__(self, entity_manager, api, resource_class=None,
+            response_key=None, plural_response_key=None, uri_base=None):
+        # need the entity manager to materialize the CloudMonitorAlarm object
+        self.entity_manager = entity_manager
+        _PaginationManager.__init__(self, api, resource_class=resource_class,
+            response_key=response_key, plural_response_key=plural_response_key,
+            uri_base=uri_base)
+
     def create(self, check, notification_plan, criteria=None,
             disabled=False, label=None, name=None, metadata=None):
         """
@@ -915,8 +924,10 @@ class CloudMonitorAlarm(BaseResource):
     def __init__(self, manager, info, entity, key=None, loaded=False):
         super(CloudMonitorAlarm, self).__init__(manager, info, key=key,
                 loaded=loaded)
+        if entity is None:
+            entity = info['entity_id']
         if not isinstance(entity, CloudMonitorEntity):
-            entity = manager.get(entity)
+            entity = manager.entity_manager.get(entity)
         self.entity = entity
 
 

--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -562,18 +562,20 @@ class CloudMonitorCheckManager(_PaginationManager):
         if details is None:
             raise exc.MissingMonitoringCheckDetails("The required 'details' "
                     "parameter was not passed to the create_check() method.")
-        if not (target_alias or target_hostname):
-            raise exc.MonitoringCheckTargetNotSpecified("You must specify "
-                    "either the 'target_alias' or 'target_hostname' when "
-                    "creating a check.")
         ctype = utils.get_id(check_type)
         is_remote = ctype.startswith("remote")
         monitoring_zones_poll = utils.coerce_to_list(monitoring_zones_poll)
         monitoring_zones_poll = [utils.get_id(mzp)
                 for mzp in monitoring_zones_poll]
-        if is_remote and not monitoring_zones_poll:
-            raise exc.MonitoringZonesPollMissing("You must specify the "
+        # only require monitoring_zones and targets for remote checks
+        if is_remote:
+            if not monitoring_zones_poll:
+                raise exc.MonitoringZonesPollMissing("You must specify the "
                     "'monitoring_zones_poll' parameter for remote checks.")
+            if not (target_alias or target_hostname):
+                raise exc.MonitoringCheckTargetNotSpecified("You must "
+                    "specify either the 'target_alias' or 'target_hostname' "
+                    "when creating a remote check.")
         body = {"label": label or name,
                 "details": details,
                 "disabled": disabled,
@@ -589,7 +591,7 @@ class CloudMonitorCheckManager(_PaginationManager):
         else:
             uri = "/%s" % self.uri_base
         try:
-            resp, resp_body = self.api.method_post(uri, body=body)
+            resp = self.api.method_post(uri, body=body)[0]
         except exc.BadRequest as e:
             msg = e.message
             dtls = e.details
@@ -597,7 +599,6 @@ class CloudMonitorCheckManager(_PaginationManager):
             if match:
                 missing = match.groups()[0].replace("details.", "")
                 if missing in details:
-                    errcls = exc.InvalidMonitoringCheckDetails
                     errmsg = "".join(["The value passed for '%s' in the ",
                             "details parameter is not valid."]) % missing
                 else:
@@ -611,10 +612,17 @@ class CloudMonitorCheckManager(_PaginationManager):
                     # Info is in the 'details'
                     raise exc.InvalidMonitoringCheckDetails("Validation "
                             "failed. Error: '%s'." % dtls)
+            # its something other than validation error; probably
+            # limits exceeded, but raise it instead of failing silently
+            raise e
         else:
             if resp.status_code == 201:
                 check_id = resp.headers["x-object-id"]
                 return self.get(check_id)
+            # don't fail silently here either; raise an error
+            # if we get an unexpected response code
+            raise exc.ClientException("Unknown response code creating check;"
+                " expected 201, got %s" % resp.status_code)
 
 
     def update(self, check, label=None, name=None, disabled=None,

--- a/pyrax/cloudnetworks.py
+++ b/pyrax/cloudnetworks.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from pyrax.client import BaseClient
 import pyrax.exceptions as exc

--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 # Since we use the novaclient package, we need to expose its exception
 # classes here.
@@ -478,7 +479,7 @@ def from_response(response, body):
             message = body.get("message")
             details = body.get("details")
             if message is details is None:
-                error = body[body.keys()[0]]
+                error = body[next(iter(body))]
                 if isinstance(error, dict):
                     message = error.get("message", None)
                     details = error.get("details", None)

--- a/pyrax/fakes.py
+++ b/pyrax/fakes.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
 import json
 import os
 import random

--- a/pyrax/fakes.py
+++ b/pyrax/fakes.py
@@ -22,6 +22,7 @@ from pyrax.clouddatabases import CloudDatabaseVolume
 from pyrax.cloudblockstorage import CloudBlockStorageClient
 from pyrax.cloudblockstorage import CloudBlockStorageManager
 from pyrax.cloudblockstorage import CloudBlockStorageSnapshot
+from pyrax.cloudblockstorage import CloudBlockStorageSnapshotManager
 from pyrax.cloudblockstorage import CloudBlockStorageVolume
 from pyrax.cloudloadbalancers import CloudLoadBalancer
 from pyrax.cloudloadbalancers import CloudLoadBalancerManager
@@ -362,6 +363,14 @@ class FakeBlockStorageClient(CloudBlockStorageClient):
         ident = FakeIdentity()
         super(FakeBlockStorageClient, self).__init__(ident, "fakeuser",
                 "fakepassword", *args, **kwargs)
+
+
+class FakeSnapshotManager(CloudBlockStorageSnapshotManager):
+    def __init__(self, api=None, *args, **kwargs):
+        ident = FakeIdentity()
+        if api is None:
+            api = FakeBlockStorageClient(ident)
+        super(FakeSnapshotManager, self).__init__(api, *args, **kwargs)
 
 
 class FakeLoadBalancerClient(CloudLoadBalancerClient):

--- a/pyrax/http.py
+++ b/pyrax/http.py
@@ -13,6 +13,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 """
 Wrapper around the requests library. Used for making all HTTP calls.
 """

--- a/pyrax/identity/keystone_identity.py
+++ b/pyrax/identity/keystone_identity.py
@@ -18,7 +18,7 @@ class KeystoneIdentity(BaseIdentity):
     _default_region = "RegionOne"
 
     def _get_auth_endpoint(self):
-        ep = pyrax.get_setting("auth_endpoint")
+        ep = self._auth_endpoint or pyrax.get_setting("auth_endpoint")
         if ep is None:
             raise exc.EndpointNotDefined("No auth endpoint has been specified.")
         return ep

--- a/pyrax/image.py
+++ b/pyrax/image.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 

--- a/pyrax/manager.py
+++ b/pyrax/manager.py
@@ -16,6 +16,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 """
 Base utilities to build API operation managers and objects on top of.

--- a/pyrax/queueing.py
+++ b/pyrax/queueing.py
@@ -15,6 +15,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from functools import wraps
 import json

--- a/pyrax/resource.py
+++ b/pyrax/resource.py
@@ -16,6 +16,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 """
 Base utilities to build API operation managers and objects on top of.
@@ -68,9 +69,8 @@ class BaseResource(object):
         corresponding attributes on the object.
         """
         for (key, val) in six.iteritems(info):
-            if isinstance(key, six.text_type):
-                key = key.encode(pyrax.get_encoding())
-            elif isinstance(key, bytes):
+            # Keys must be str, not bytes
+            if isinstance(key, bytes):
                 key = key.decode("utf-8")
             setattr(self, key, val)
 

--- a/pyrax/service_catalog.py
+++ b/pyrax/service_catalog.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import, unicode_literals
 
 
 import pyrax.exceptions as exc

--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -244,7 +244,7 @@ def get_checksum(content, encoding="utf8", block_size=8192):
 
     try:
         isfile = os.path.isfile(content)
-    except TypeError:
+    except (TypeError, ValueError):
         # Will happen with binary content.
         isfile = False
     if isfile:

--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import email.utils
@@ -237,10 +237,9 @@ def get_checksum(content, encoding="utf8", block_size=8192):
     md = hashlib.md5()
 
     def safe_update(txt):
-        try:
-            md.update(txt)
-        except UnicodeEncodeError:
-            md.update(txt.encode(encoding))
+        if isinstance(txt, six.text_type):
+            txt = txt.encode(encoding)
+        md.update(txt)
 
     try:
         isfile = os.path.isfile(content)
@@ -322,29 +321,27 @@ def folder_size(pth, ignore=None):
 
     ignore = coerce_to_list(ignore)
 
-    def get_size(total, root, names):
+    total = 0
+    for root, _, names in os.walk(pth):
         paths = [os.path.realpath(os.path.join(root, nm)) for nm in names]
         for pth in paths[::-1]:
             if not os.path.exists(pth):
                 paths.remove(pth)
-            elif os.path.isdir(pth):
-                # Don't count folder stat sizes
-                paths.remove(pth)
             elif match_pattern(pth, ignore):
                 paths.remove(pth)
-        total[0] += sum(os.stat(pth).st_size for pth in paths)
+        total += sum(os.stat(pth).st_size for pth in paths)
 
-    # Need a mutable to pass
-    total = [0]
-    os.path.walk(pth, get_size, total)
-    return total[0]
+    return total
 
 
 def add_method(obj, func, name=None):
     """Adds an instance method to an object."""
     if name is None:
-        name = func.func_name
-    method = types.MethodType(func, obj, obj.__class__)
+        name = func.__name__
+    if sys.version_info < (3,):
+        method = types.MethodType(func, obj, obj.__class__)
+    else:
+        method = types.MethodType(func, obj)
     setattr(obj, name, method)
 
 

--- a/pyrax/version.py
+++ b/pyrax/version.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 version = "1.9.3"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class sdist(_sdist):
         # Expand macros in pyrax.spec.in
         spec_in = open('pyrax.spec.in', 'r')
         spec = open('pyrax.spec', 'w')
-        for line in spec_in.xreadlines():
+        for line in spec_in:
             if "@VERSION@" in line:
                 line = line.replace("@VERSION@", version)
             elif "@RELEASE@" in line:
@@ -81,7 +81,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Operating System :: OS Independent",
     ],
     install_requires=[

--- a/tests/unit/base_test.py
+++ b/tests/unit/base_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import json
 import time

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import unittest
@@ -110,7 +111,7 @@ class AutoscaleTest(unittest.TestCase):
         image = utils.random_unicode()
         disk_config = utils.random_unicode()
         metadata = utils.random_unicode()
-        personality = utils.random_unicode()
+        personality = utils.random_unicode().encode("utf-8")  # Must be bytes
         networks = utils.random_unicode()
         load_balancers = utils.random_unicode()
         key_name = utils.random_unicode()
@@ -1189,7 +1190,7 @@ class AutoscaleTest(unittest.TestCase):
         flavor = utils.random_unicode()
         disk_config = None
         metadata = None
-        personality = [{"path": "/tmp/testing", "contents": "testtest"}]
+        personality = [{"path": "/tmp/testing", "contents": b"testtest"}]
         scaling_policies = None
         networks = utils.random_unicode()
         lb = fakes.FakeLoadBalancer()
@@ -1215,7 +1216,7 @@ class AutoscaleTest(unittest.TestCase):
                             "metadata": {},
                             "name": server_name,
                             "personality": [{"path": "/tmp/testing",
-                                             "contents": "dGVzdHRlc3Q="}],
+                                             "contents": b"dGVzdHRlc3Q="}],
                             "networks": networks,
                             "key_name": key_name}
                         },

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import, unicode_literals
+
 import datetime
 import json
 import os
@@ -8,6 +10,7 @@ import pkg_resources
 import requests
 import unittest
 
+import six
 from six.moves import urllib
 
 from mock import patch
@@ -46,7 +49,7 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(ret, expected)
 
     def test_safe_quote_unicode(self):
-        ret = _safe_quote(unichr(1000))
+        ret = _safe_quote(six.unichr(1000))
         expected = "%CF%A8"
         self.assertEqual(ret, expected)
 

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import unittest

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -64,7 +64,7 @@ class CloudBlockStorageTest(unittest.TestCase):
 
     def test_assure_volume(self):
         class TestClient(object):
-            _manager = fakes.FakeManager()
+            _manager = fakes.FakeBlockStorageManager()
 
             @assure_volume
             def test_method(self, volume):
@@ -81,7 +81,7 @@ class CloudBlockStorageTest(unittest.TestCase):
 
     def test_assure_snapshot(self):
         class TestClient(object):
-            _snapshot_manager = fakes.FakeManager()
+            _snapshot_manager = fakes.FakeSnapshotManager()
 
             @assure_snapshot
             def test_method(self, snapshot):
@@ -189,7 +189,24 @@ class CloudBlockStorageTest(unittest.TestCase):
                 name=name, description=desc, force=False)
         BaseManager.create = sav
 
-    def test_update_volume(self):
+    def test_vol_update_volume(self):
+        vol = self.volume
+        mgr = vol.manager
+        mgr.update = Mock()
+        nm = utils.random_unicode()
+        desc = utils.random_unicode()
+        vol.update(display_name=nm, display_description=desc)
+        mgr.update.assert_called_once_with(vol, display_name=nm,
+                display_description=desc)
+
+    def test_vol_rename(self):
+        vol = self.volume
+        nm = utils.random_unicode()
+        vol.update = Mock()
+        vol.rename(nm)
+        vol.update.assert_called_once_with(display_name=nm)
+
+    def test_mgr_update_volume(self):
         clt = self.client
         vol = self.volume
         mgr = clt._manager
@@ -202,7 +219,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         mgr.update(vol, display_name=name, display_description=desc)
         mgr.api.method_put.assert_called_once_with(exp_uri, body=exp_body)
 
-    def test_update_volume_empty(self):
+    def test_mgr_update_volume_empty(self):
         clt = self.client
         vol = self.volume
         mgr = clt._manager
@@ -456,6 +473,22 @@ class CloudBlockStorageTest(unittest.TestCase):
         pyrax.cloudblockstorage.RETRY_INTERVAL = 0.1
         self.assertRaises(exc.ClientException, snap.delete)
 
+    def test_snapshot_update(self):
+        snap = self.snapshot
+        snap.manager.update = Mock()
+        nm = utils.random_unicode()
+        desc = utils.random_unicode()
+        snap.update(display_name=nm, display_description=desc)
+        snap.manager.update.assert_called_once_with(snap, display_name=nm,
+                display_description=desc)
+
+    def test_snapshot_rename(self):
+        snap = self.snapshot
+        snap.update = Mock()
+        nm = utils.random_unicode()
+        snap.rename(nm)
+        snap.update.assert_called_once_with(display_name=nm)
+
     def test_volume_name_property(self):
         vol = self.volume
         nm = utils.random_unicode()
@@ -492,7 +525,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         snap.description = nm
         self.assertEqual(snap.description, snap.display_description)
 
-    def test_update_snapshot(self):
+    def test_mgr_update_snapshot(self):
         clt = self.client
         snap = self.snapshot
         mgr = clt._snapshot_manager
@@ -505,7 +538,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         mgr.update(snap, display_name=name, display_description=desc)
         mgr.api.method_put.assert_called_once_with(exp_uri, body=exp_body)
 
-    def test_update_snapshot_empty(self):
+    def test_mgr_update_snapshot_empty(self):
         clt = self.client
         snap = self.snapshot
         mgr = clt._snapshot_manager
@@ -518,20 +551,36 @@ class CloudBlockStorageTest(unittest.TestCase):
         vol = self.volume
         name = utils.random_unicode()
         desc = utils.random_unicode()
-        clt._manager.update = Mock()
+        vol.update = Mock()
         clt.update(vol, display_name=name, display_description=desc)
-        clt._manager.update.assert_called_once_with(vol, display_name=name,
+        vol.update.assert_called_once_with(display_name=name,
                 display_description=desc)
+
+    def test_clt_rename(self):
+        clt = self.client
+        vol = self.volume
+        nm = utils.random_unicode()
+        clt.update = Mock()
+        clt.rename(vol, nm)
+        clt.update.assert_called_once_with(vol, display_name=nm)
 
     def test_clt_update_snapshot(self):
         clt = self.client
         snap = self.snapshot
         name = utils.random_unicode()
         desc = utils.random_unicode()
-        clt._snapshot_manager.update = Mock()
+        snap.update = Mock()
         clt.update_snapshot(snap, display_name=name, display_description=desc)
-        clt._snapshot_manager.update.assert_called_once_with(snap,
-                display_name=name, display_description=desc)
+        snap.update.assert_called_once_with(display_name=name,
+                display_description=desc)
+
+    def test_clt_rename_snapshot(self):
+        clt = self.client
+        snap = self.snapshot
+        nm = utils.random_unicode()
+        clt.update_snapshot = Mock()
+        clt.rename_snapshot(snap, nm)
+        clt.update_snapshot.assert_called_once_with(snap, display_name=nm)
 
     def test_get_snapshot(self):
         clt = self.client

--- a/tests/unit/test_cloud_databases.py
+++ b/tests/unit/test_cloud_databases.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import time

--- a/tests/unit/test_cloud_loadbalancers.py
+++ b/tests/unit/test_cloud_loadbalancers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import unittest

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import random

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -8,6 +8,7 @@ import unittest
 from mock import patch
 from mock import MagicMock as Mock
 
+from pyrax.cloudmonitoring import CloudMonitorAgentToken
 from pyrax.cloudmonitoring import CloudMonitorAlarm
 from pyrax.cloudmonitoring import CloudMonitorAlarmManager
 from pyrax.cloudmonitoring import CloudMonitorCheck
@@ -988,6 +989,99 @@ class CloudMonitoringTest(unittest.TestCase):
         ent.get_alarm = Mock(return_value=alm)
         alm.reload()
         self.assertEqual(alm._info, info)
+
+    def test_token_get(self):
+        mgr = self.client._token_manager
+        resp = {
+            "id": "someId",
+            "token": "4c5e28f0-0b3f-11e1-860d-c55c4705a286:1234",
+            "label": "aLabel"
+        }
+        mgr.api.method_get = Mock(return_value=(Mock(), resp))
+        token = mgr.get("someId")
+        mgr.api.method_get.assert_called_once_with("/agent_tokens/someId")
+        self.assertIsInstance(token, CloudMonitorAgentToken)
+        self.assertEqual(resp['token'], token.token)
+        self.assertEqual(resp['label'], token.label)
+        self.assertEqual(resp['label'], token.name)
+        self.assertEqual(resp['id'], token.id)
+
+    def test_token_list(self):
+        mgr = self.client._token_manager
+        exp_token = "4c5e28f0-0b3f-11e1-860d-c55c4705a286:1234"
+        exp_lable = "aLabel"
+        resp = {
+            "values": [{
+                "token": exp_token,
+                "label": exp_lable
+            }],
+            "metadata": {
+                "count": 1,
+                "limit": 50,
+                "marker": None,
+                "next_marker": None,
+                "next_href": None
+            }
+        }
+        mgr.api.method_get = Mock(return_value=(Mock(), resp))
+        tokens = mgr.list()
+        mgr.api.method_get.assert_called_once_with("/agent_tokens")
+        self.assertIsInstance(tokens, list)
+        self.assertEqual(1, len(tokens))
+        token = tokens[0]
+        self.assertIsInstance(token, CloudMonitorAgentToken)
+        self.assertEqual(exp_token, token.token)
+        self.assertEqual(exp_lable, token.label)
+        self.assertEqual(exp_lable, token.name)
+
+    def test_token_create(self):
+        mgr = self.client._token_manager
+        req = {'label': "aLabel"}
+        data = {
+            "id": "someId",
+            "token": "4c5e28f0-0b3f-11e1-860d-c55c4705a286:1234",
+            "label": "aLabel"
+        }
+        resp = Mock()
+        resp.headers = {"location": "/someId"}
+        mgr.api.method_post = Mock(return_value=(resp, None))
+        mgr.api.method_get = Mock(return_value=(resp, data))
+        token = mgr.create("aLabel")
+        mgr.api.method_post.assert_called_once_with("/agent_tokens",
+            body=req)
+        mgr.api.method_get.assert_called_once_with('/agent_tokens/someId')
+        self.assertIsInstance(token, CloudMonitorAgentToken)
+        self.assertEqual(data['token'], token.token)
+        self.assertEqual(data['label'], token.label)
+        self.assertEqual(data['label'], token.name)
+        self.assertEqual(data['id'], token.id)
+
+    def test_token_delete(self):
+        mgr = self.client._token_manager
+        mgr.api.method_delete = Mock(return_value=(Mock(), None))
+        mgr.delete("someId")
+        mgr.api.method_delete.assert_called_once_with("/agent_tokens/someId")
+
+    def test_token_update(self):
+        mgr = self.client._token_manager
+        req = { 'label': "aNewLabel"}
+        data = {
+            "id": "someId",
+            "token": "4c5e28f0-0b3f-11e1-860d-c55c4705a286:1234",
+            "label": "aNewLabel"
+        }
+        resp = Mock()
+        mgr.api.method_put = Mock(return_value=(resp, None))
+        mgr.api.method_get = Mock(return_value=(resp, data))
+        token = mgr.update('someId', "aNewLabel")
+        mgr.api.method_put.assert_called_once_with("/agent_tokens/someId",
+            body=req)
+        mgr.api.method_get.assert_called_once_with("/agent_tokens/someId")
+        self.assertIsInstance(token, CloudMonitorAgentToken)
+        self.assertEqual(data['token'], token.token)
+        self.assertEqual(data['label'], token.label)
+        self.assertEqual(data['label'], token.name)
+        self.assertEqual(data['id'], token.id)
 
     def test_clt_get_account(self):
         clt = self.client

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -8,8 +8,8 @@ import unittest
 from mock import patch
 from mock import MagicMock as Mock
 
-import pyrax.cloudnetworks
 from pyrax.cloudmonitoring import CloudMonitorAlarm
+from pyrax.cloudmonitoring import CloudMonitorAlarmManager
 from pyrax.cloudmonitoring import CloudMonitorCheck
 from pyrax.cloudmonitoring import CloudMonitorCheckType
 from pyrax.cloudmonitoring import CloudMonitorNotification
@@ -23,7 +23,6 @@ import pyrax.exceptions as exc
 import pyrax.utils as utils
 
 from pyrax import fakes
-
 
 
 class CloudMonitoringTest(unittest.TestCase):
@@ -921,11 +920,11 @@ class CloudMonitoringTest(unittest.TestCase):
 
     def test_alarm(self):
         ent = self.entity
-        clt = self.client
-        mgr = clt._entity_manager
+        mgr = Mock(spec=CloudMonitorAlarmManager)
+        mgr.entity_manager = ent.manager
         id_ = utils.random_unicode()
         nm = utils.random_unicode()
-        mgr.get = Mock(return_value=ent)
+        ent.manager.get = Mock(return_value=ent)
         alm = CloudMonitorAlarm(mgr, info={"id": id_, "label": nm},
                 entity="fake")
         self.assertEqual(alm.entity, ent)

--- a/tests/unit/test_cloud_monitoring.py
+++ b/tests/unit/test_cloud_monitoring.py
@@ -451,7 +451,24 @@ class CloudMonitoringTest(unittest.TestCase):
         ent = self.entity
         mgr = ent._check_manager
         self.assertRaises(exc.MonitoringCheckTargetNotSpecified,
-                mgr.create_check, ent, details="fake")
+                mgr.create_check, ent, details="fake",
+                check_type="remote.http",
+                monitoring_zones_poll=['foo', 'bar'])
+
+    def test_create_agent_check(self):
+        ent = self.entity
+        ent.id = 9876
+        fake_api = Mock()
+        ent._check_manager.api = fake_api
+        fake_resp = Mock()
+        fake_resp.headers = {'x-object-id': 1234}
+        fake_resp.status_code = 201
+        fake_api.method_post.return_value = (fake_resp, None)
+        ent._check_manager.get = Mock()
+        ent._check_manager.get.return_value = self.check
+        ret = ent._check_manager.create_check(label="test",
+            check_type="agent.memory", details={}, timeout=10, period=30)
+        self.assertEqual(ret, self.check)
 
     def test_entity_mgr_create_check_no_mz_poll(self):
         ent = self.entity

--- a/tests/unit/test_cloud_networks.py
+++ b/tests/unit/test_cloud_networks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import unittest

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import pickle
 import unittest

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
 import json
 import logging
 import random
@@ -29,7 +31,7 @@ class HttpTest(unittest.TestCase):
         pass
 
     def test_request(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)
@@ -43,7 +45,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_no_json(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         resp.json = Mock(side_effect=ValueError(""))
@@ -58,7 +60,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_exception(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         resp.status_code = 404
@@ -71,7 +73,7 @@ class HttpTest(unittest.TestCase):
                 headers=headers)
 
     def test_request_data(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)
@@ -86,7 +88,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_body(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import json
@@ -520,7 +521,7 @@ class IdentityTest(unittest.TestCase):
         key = "fake%api%key"
         ident.authenticate = Mock()
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("[rackspace_cloud]\n")
                 ff.write("username = %s\n" % user)
                 ff.write("api_key = %s\n" % key)
@@ -529,7 +530,7 @@ class IdentityTest(unittest.TestCase):
         self.assertEqual(ident.password, key)
         # Using 'password' instead of 'api_key'
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("[rackspace_cloud]\n")
                 ff.write("username = %s\n" % user)
                 ff.write("password = %s\n" % key)
@@ -541,19 +542,19 @@ class IdentityTest(unittest.TestCase):
                 "doesn't exist")
         # Missing section
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("user = x\n")
             self.assertRaises(exc.InvalidCredentialFile,
                     ident.set_credential_file, tmpname)
         # Incorrect section
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("[bad_section]\nusername = x\napi_key = y\n")
             self.assertRaises(exc.InvalidCredentialFile,
                     ident.set_credential_file, tmpname)
         # Incorrect option
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("[rackspace_cloud]\nuserbad = x\napi_key = y\n")
             self.assertRaises(exc.InvalidCredentialFile,
                     ident.set_credential_file, tmpname)
@@ -565,7 +566,7 @@ class IdentityTest(unittest.TestCase):
         password = "fakeapikey"
         tenant_id = "faketenantid"
         with utils.SelfDeletingTempfile() as tmpname:
-            with file(tmpname, "wb") as ff:
+            with open(tmpname, "w") as ff:
                 ff.write("[keystone]\n")
                 ff.write("username = %s\n" % user)
                 ff.write("password = %s\n" % password)

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -259,7 +259,7 @@ class IdentityTest(unittest.TestCase):
         ret = ep._create_client(None, None, public)
         self.assertEqual(ret, fake_client)
         pyrax.connect_to_cloudservers.assert_called_once_with(region=ep.region,
-                context=ep.identity)
+                context=ep.identity, verify_ssl=True)
         pyrax.connect_to_cloudservers = sav_conn
         pyrax.get_setting = sav_gs
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import os
 import random

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import random
 import unittest

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import json
 import os
 import unittest
 import warnings
 
+import six
 from six.moves import reload_module as reload
 
 from mock import patch
@@ -257,7 +259,7 @@ class PyraxInitTest(unittest.TestCase):
 
     def test_set_credential_file(self):
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as tmp:
+            with open(tmpname, "w") as tmp:
                 tmp.write("[keystone]\n")
                 tmp.write("username = %s\n" % self.username)
                 tmp.write("password = %s\n" % self.password)
@@ -269,7 +271,7 @@ class PyraxInitTest(unittest.TestCase):
 
     def test_set_bad_credential_file(self):
         with utils.SelfDeletingTempfile() as tmpname:
-            with open(tmpname, "wb") as tmp:
+            with open(tmpname, "w") as tmp:
                 tmp.write("[keystone]\n")
                 tmp.write("username = bad\n")
                 tmp.write("password = creds\n")
@@ -488,8 +490,8 @@ class PyraxInitTest(unittest.TestCase):
         pyrax.get_setting = sav
 
     def test_import_fail(self):
-        import __builtin__
-        sav_import = __builtin__.__import__
+        _builtin = six.moves.builtins
+        sav_import = _builtin.__import__
 
         def fake_import(nm, *args):
             if nm == "identity":
@@ -497,9 +499,9 @@ class PyraxInitTest(unittest.TestCase):
             else:
                 return sav_import(nm, *args)
 
-        __builtin__.__import__ = fake_import
+        _builtin.__import__ = fake_import
         self.assertRaises(ImportError, reload, pyrax)
-        __builtin__.__import__ = sav_import
+        _builtin.__import__ = sav_import
         reload(pyrax)
 
 

--- a/tests/unit/test_queues.py
+++ b/tests/unit/test_queues.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import os
 import random

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import hashlib
@@ -34,9 +35,12 @@ class UtilsTest(unittest.TestCase):
         pass
 
     def test_runproc(self):
-        currdir = os.getcwd()
+        if hasattr(os, 'getcwdb'):
+            currdir = os.getcwdb()
+        else:
+            currdir = os.getcwd()
         out, err = utils.runproc("pwd")
-        self.assertEqual(err, "")
+        self.assertEqual(err, b"")
         self.assertEqual(out.strip(), currdir)
 
     def test_self_deleting_temp_file(self):
@@ -64,7 +68,7 @@ class UtilsTest(unittest.TestCase):
         self.assertRaises(AttributeError, getattr, dd, "bogus")
 
     def test_get_checksum_from_string(self):
-        test = utils.random_ascii()
+        test = utils.random_ascii().encode("ascii")
         md = hashlib.md5()
         md.update(test)
         expected = md.hexdigest()
@@ -99,14 +103,14 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(expected, received)
 
     def test_get_checksum_from_file(self):
-        test = "some random text"
+        test = b"some random text"
         md = hashlib.md5()
         md.update(test)
         expected = md.hexdigest()
         with utils.SelfDeletingTempfile() as tmp:
-            with open(tmp, "w") as testfile:
+            with open(tmp, "wb") as testfile:
                 testfile.write(test)
-            with open(tmp, "r") as testfile:
+            with open(tmp, "rb") as testfile:
                 received = utils.get_checksum(testfile)
         self.assertEqual(expected, received)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = pep8, py27, pypy
+envlist = pep8, py27, py34, pypy
 
 [testenv]
 deps =
     mock
     nose
     coverage
+    six
 
 commands =
     {envpython} -V


### PR DESCRIPTION
Some notes on how and why things were converted or fixed:
- `absolute_import`, `print_function`, `unicode_literals` are all imported so both versions function the same. These are imported in all `.py` files. This uncovered a number of bugs where bytes were required, but strings supplied. These bugs were hidden by Python2 defaulting to bytes.
- files opened with `"wb"` must write bytes out, and those opened with `"w"` must write strings.
- `file`s are iterable, no need for `xreadlines`
- `pyrax/object_storage.py`, line 1899: Comparing None with an int is a TypeError. fsize is only None when the filesize is unknown. If the filesize is unknown, proper chunking is not possible, so the file is uploaded as is. This matches the previous behaviour, as in Python2 `None < 1.0`.
- `next(iter)` instead of `iter.next()`
- `dict.keys()` returns an iterable, instead of a list, so indexing and `random.choice` no longer work.
- `os.path.walk()` has been changed to `os.walk()`, and functions rewritten to handle this
