### PR TITLE
Add Python 3 support to tox, Travis CI, setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ all: rpms
 clean:
 	rm -rf dist/ build/ rpm-build/ rpms/
 	rm -rf docs/*.gz MANIFEST *~
+	rm -rf .tox/
 	find . -name '*.pyc' -exec rm -f {} \;
+	find . -name '__pycache__' -exec rm -rf {} \; -prune
 
 build: clean
 	python setup.py build -f

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
 * Cloud Backups
 * Add Cloud Files container sync
 * Add support for Cloud Networks virtual interfaces
-
-* Python 3 compatibilty

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Operating System :: OS Independent",
     ],
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = pep8, py27, pypy
+envlist = pep8, py27, py34, pypy
 
 [testenv]
 deps =
     mock
     nose
     coverage
+    six
 
 commands =
     {envpython} -V


### PR DESCRIPTION
The tests for Python 3 will fail until the other incoming pull requests are merged.
