### PR TITLE
Change usages of os.path.walk to os.walk

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -3277,7 +3277,7 @@ class FolderUploader(threading.Thread):
         return os.path.basename(pth.rstrip(os.sep))
 
 
-    def upload_files_in_folder(self, arg, dirname, fnames):
+    def upload_files_in_folder(self, dirname, fnames):
         """Handles the iteration across files within a folder."""
         if utils.match_pattern(dirname, self.ignore):
             return False
@@ -3287,9 +3287,6 @@ class FolderUploader(threading.Thread):
             if self.client._should_abort_folder_upload(self.upload_key):
                 return
             full_path = os.path.join(dirname, fname)
-            if os.path.isdir(full_path):
-                # Skip folders; os.walk will include them in the next pass.
-                continue
             obj_name = os.path.relpath(full_path, self.root_folder)
             obj_size = os.stat(full_path).st_size
             self.client.upload_file(self.container, full_path,
@@ -3301,8 +3298,8 @@ class FolderUploader(threading.Thread):
         """Starts the uploading thread."""
         root_path, folder_name = os.path.split(self.root_folder)
         self.root_folder = os.path.join(root_path, folder_name)
-        os.path.walk(self.root_folder, self.upload_files_in_folder, None)
-
+        for dirname, _, fnames in os.walk(self.root_folder):
+            self.upload_files_in_folder(dirname, fnames)
 
 
 class BulkDeleter(threading.Thread):

--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -322,22 +322,17 @@ def folder_size(pth, ignore=None):
 
     ignore = coerce_to_list(ignore)
 
-    def get_size(total, root, names):
+    total = 0
+    for root, _, names in os.walk(pth):
         paths = [os.path.realpath(os.path.join(root, nm)) for nm in names]
         for pth in paths[::-1]:
             if not os.path.exists(pth):
                 paths.remove(pth)
-            elif os.path.isdir(pth):
-                # Don't count folder stat sizes
-                paths.remove(pth)
             elif match_pattern(pth, ignore):
                 paths.remove(pth)
-        total[0] += sum(os.stat(pth).st_size for pth in paths)
+        total += sum(os.stat(pth).st_size for pth in paths)
 
-    # Need a mutable to pass
-    total = [0]
-    os.path.walk(pth, get_size, total)
-    return total[0]
+    return total
 
 
 def add_method(obj, func, name=None):

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -3477,12 +3477,11 @@ class ObjectStorageTest(unittest.TestCase):
         ignore = "*FAKE*"
         upload_key = utils.random_unicode()
         folder_up = FolderUploader(root_folder, cont, ignore, upload_key, clt)
-        arg = utils.random_unicode()
         dirname = "FAKE DIRECTORY"
         fname1 = utils.random_unicode()
         fname2 = utils.random_unicode()
         fnames = [fname1, fname2]
-        ret = folder_up.upload_files_in_folder(arg, dirname, fnames)
+        ret = folder_up.upload_files_in_folder(dirname, fnames)
         self.assertFalse(ret)
 
     def test_folder_uploader_upload_files_in_folder_abort(self):
@@ -3492,14 +3491,13 @@ class ObjectStorageTest(unittest.TestCase):
         ignore = "*FAKE*"
         upload_key = utils.random_unicode()
         folder_up = FolderUploader(root_folder, cont, ignore, upload_key, clt)
-        arg = utils.random_unicode()
         dirname = utils.random_unicode()
         fname1 = utils.random_unicode()
         fname2 = utils.random_unicode()
         fnames = [fname1, fname2]
         clt._should_abort_folder_upload = Mock(return_value=True)
         clt.upload_file = Mock()
-        ret = folder_up.upload_files_in_folder(arg, dirname, fnames)
+        ret = folder_up.upload_files_in_folder(dirname, fnames)
         self.assertEqual(clt.upload_file.call_count, 0)
 
     def test_folder_uploader_upload_files_in_folder(self):
@@ -3507,21 +3505,20 @@ class ObjectStorageTest(unittest.TestCase):
         cont = self.container
         ignore = "*FAKE*"
         upload_key = utils.random_unicode()
-        arg = utils.random_unicode()
         fname1 = utils.random_ascii()
         fname2 = utils.random_ascii()
         fname3 = utils.random_ascii()
         with utils.SelfDeletingTempDirectory() as tmpdir:
-            fnames = [tmpdir, fname1, fname2, fname3]
-            for fname in fnames[1:]:
+            fnames = [fname1, fname2, fname3]
+            for fname in fnames:
                 pth = os.path.join(tmpdir, fname)
                 open(pth, "w").write("faketext")
             clt._should_abort_folder_upload = Mock(return_value=False)
             clt.upload_file = Mock()
             clt._update_progress = Mock()
             folder_up = FolderUploader(tmpdir, cont, ignore, upload_key, clt)
-            ret = folder_up.upload_files_in_folder(arg, tmpdir, fnames)
-            self.assertEqual(clt.upload_file.call_count, len(fnames) - 1)
+            ret = folder_up.upload_files_in_folder(tmpdir, fnames)
+            self.assertEqual(clt.upload_file.call_count, len(fnames))
 
     def test_folder_uploader_run(self):
         clt = self.client


### PR DESCRIPTION
`os.path.walk` does not exist in Python 3, but `os.walk` exists in both
Python 2 and 3. Plus, `os.walk` presents a nicer interface.
