### PR TITLE
Use iterators in a Python 3 compatible manner

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -489,7 +489,7 @@ class BaseIdentity(object):
             raise exc.AuthenticationFailed("Incorrect/unauthorized "
                     "credentials received")
         elif resp.status_code > 299:
-            msg = resp_body[resp_body.keys()[0]]["message"]
+            msg = resp_body[next(iter(resp_body))]["message"]
             raise exc.AuthenticationFailed("%s - %s." % (resp.reason, msg))
         return resp, resp_body
 

--- a/pyrax/exceptions.py
+++ b/pyrax/exceptions.py
@@ -478,7 +478,7 @@ def from_response(response, body):
             message = body.get("message")
             details = body.get("details")
             if message is details is None:
-                error = body[body.keys()[0]]
+                error = body[next(iter(body))]
                 if isinstance(error, dict):
                     message = error.get("message", None)
                     details = error.get("details", None)

--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -2827,7 +2827,7 @@ class StorageClient(BaseClient):
                     if self.count > self.interval:
                         self.count = 0
                         print(".")
-                ret = self.gen.next()
+                ret = next(self.gen)
                 self.processed += len(ret)
                 return ret
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class sdist(_sdist):
         # Expand macros in pyrax.spec.in
         spec_in = open('pyrax.spec.in', 'r')
         spec = open('pyrax.spec', 'w')
-        for line in spec_in.xreadlines():
+        for line in spec_in:
             if "@VERSION@" in line:
                 line = line.replace("@VERSION@", version)
             elif "@RELEASE@" in line:

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -29,7 +29,7 @@ class HttpTest(unittest.TestCase):
         pass
 
     def test_request(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)
@@ -43,7 +43,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_no_json(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         resp.json = Mock(side_effect=ValueError(""))
@@ -58,7 +58,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_exception(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         resp.status_code = 404
@@ -71,7 +71,7 @@ class HttpTest(unittest.TestCase):
                 headers=headers)
 
     def test_request_data(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)
@@ -86,7 +86,7 @@ class HttpTest(unittest.TestCase):
         self.http.req_methods[mthd] = sav_method
 
     def test_request_body(self):
-        mthd = random.choice(self.http.req_methods.keys())
+        mthd = random.choice(list(self.http.req_methods.keys()))
         sav_method = self.http.req_methods[mthd]
         resp = fakes.FakeResponse()
         self.http.req_methods[mthd] = Mock(return_value=resp)

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -2133,7 +2133,7 @@ class ObjectStorageTest(unittest.TestCase):
         resp_body = ""
         mgr.api.method_get = Mock(return_value=(resp, resp_body))
         ret = mgr._fetch_chunker(uri, chunk_size, None, obj.total_bytes)
-        self.assertRaises(StopIteration, ret.next)
+        self.assertRaises(StopIteration, lambda: next(ret))
 
     def test_sobj_mgr_fetch_partial(self):
         obj = self.obj


### PR DESCRIPTION
- `iter.next()` has been replaced by `next(iter)`
- `dict.keys()` no longer returns a `list`, so can not be indexed. It is now either explicitly cast to a `list`, or used as an iterator.
- `file.xreadlines()` is not needed, as `file` itself is iterable.
