### PR TITLE
Call types.MethodType correctly in Python 2 and 3

### DIFF
--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -343,8 +343,11 @@ def folder_size(pth, ignore=None):
 def add_method(obj, func, name=None):
     """Adds an instance method to an object."""
     if name is None:
-        name = func.func_name
-    method = types.MethodType(func, obj, obj.__class__)
+        name = func.__name__
+    if sys.version_info < (3,):
+        method = types.MethodType(func, obj, obj.__class__)
+    else:
+        method = types.MethodType(func, obj)
     setattr(obj, name, method)
 
 


### PR DESCRIPTION
The call signature for `types.MethodType` changed in Python 3, causing an error. There is no six import or similar to handle this easily, so detecting the Python version is required.
