### PR TITLE
Try importing from v2, fallback on v1_1

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -57,9 +57,12 @@ try:
     from novaclient import exceptions as _cs_exceptions
     from novaclient import auth_plugin as _cs_auth_plugin
     from novaclient.shell import OpenStackComputeShell as _cs_shell
-    from novaclient.v1_1 import client as _cs_client
-    from novaclient.v1_1.servers import Server as CloudServer
-
+    try:
+        from novaclient.v2 import client as _cs_client
+        from novaclient.v2.servers import Server as CloudServer
+    except ImportError:
+        from novaclient.v1_1 import client as _cs_client
+        from novaclient.v1_1.servers import Server as CloudServer
     from .autoscale import AutoScaleClient
     from .clouddatabases import CloudDatabaseClient
     from .cloudloadbalancers import CloudLoadBalancerClient


### PR DESCRIPTION
Release 2.21.0 of python-novaclient deprecates the v1_1 module. This
commit prevents a warning message from being displayed when importing
the latest version of python-novaclient.
