### PR TITLE
Don't convert key to bytes on Python 3. Fixes #565.

### DIFF
--- a/pyrax/resource.py
+++ b/pyrax/resource.py
@@ -68,7 +68,7 @@ class BaseResource(object):
         corresponding attributes on the object.
         """
         for (key, val) in six.iteritems(info):
-            if isinstance(key, six.text_type):
+            if isinstance(key, six.text_type) and six.PY2:
                 key = key.encode(pyrax.get_encoding())
             elif isinstance(key, bytes):
                 key = key.decode("utf-8")


### PR DESCRIPTION
Disables the first clause on Python 3. I did test and setting a 'unicode' attribute of an object on Python 2 is also acceptable, but per the [guidance on not changing Python 2 behavior](https://github.com/rackspace/pyrax/pull/477#issuecomment-58026920), I'm leaving that undesirable code in place and only disabling it when not on Python 2, thus having zero impact on the officially-supported Python versions.
