### PR TITLE
DeprecationWarning: invalid escape sequence in __init__.py

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -17,7 +17,7 @@
 
 
 # For doxygen class doc generation:
-"""
+r"""
 \mainpage Class Documentation for pyrax
 
 This module provides the Python Language Bindings for creating applications


### PR DESCRIPTION
Hello,

This is a little patch to get rid of a warning in the module docstring.