### PR TITLE
Small Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+cache:
+  - pip
 
 python:
  - 2.7

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 pyrax
 =====
 
+.. image:: https://img.shields.io/pypi/v/jira.svg
+        :target: https://pypi.python.org/pypi/jira/
+
+.. image:: https://travis-ci.com/pycontribs/jira.svg?branch=master
+        :target: https://travis-ci.com/pycontribs/jira
+
 Python SDK for OpenStack/Rackspace APIs
 
    **DEPRECATED**: Pyrax is no longer being developed or supported.
@@ -21,9 +27,6 @@ app will work fine on any standard Swift deployment.
 See the `Release
 Notes <https://github.com/rackspace/pyrax/tree/master/RELEASENOTES.md>`_
 for what has changed in the latest release
-
-.. image:: https://travis-ci.org/rackspace/pyrax.svg?branch=master
-       :target: https://travis-ci.org/rackspace/pyrax
 
 Getting Started with OpenStack/Rackspace
 ----------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,9 @@ optimize = 1
 
 [wheel]
 universal = 1
+
+[flake8]
+max-line-length=84
+exclude=build,.eggs,.tox,tests,samples
+statistics=yes
+ignore=E123,E124,E126,E127,E128,E303,E302,W606,F841,E301,F401,E305,F811,F812,W504,W605,F403,E722,F405,E999

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [install]
 optimize = 1
 
-[wheel]
-universal = 1
-
 [flake8]
 max-line-length=84
 exclude=build,.eggs,.tox,tests,samples

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 
 [testenv:pep8]
 deps =
-    pep8
+    flake8
 
 commands =
-    {envbindir}/pep8 -r --show-source --max-line-length=84 --ignore=E123,E124,E126,E127,E128,E303,E302 pyrax/
+    {envbindir}/flake8 --show-source --max-line-length=84 --ignore=E123,E124,E126,E127,E128,E303,E302,W606,F841,E301,F401,E305,F811,F812,W504,W605,F403,E722,F405,E999 pyrax/

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     flake8
 
 commands =
-    {envbindir}/flake8 --show-source --max-line-length=84 --ignore=E123,E124,E126,E127,E128,E303,E302,W606,F841,E301,F401,E305,F811,F812,W504,W605,F403,E722,F405,E999 pyrax/
+    {envbindir}/flake8 --show-source


### PR DESCRIPTION
Just getting started on cleaning up the build process with Travis CI. Switches to flake8, builds the sdist and wheel as part of Travis. Enables Travis caching. Fixes links in the README.