### PR TITLE
Switch to GitHub flow

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,9 +3,8 @@ whether or not the change may be accepted. Pyrax is in the process of being
 deprecated in favor of the OpenStack SDK. We will announce the process and
 timelines for this deprecation as soon as we can.
 
-Once a pull request has been deemed the right approach, please be sure that
-*all* pull requests are made against the **working** branch of the project,
-as we reserve the **master** branch for full releases.
+Please set all pull requests to merge to the `master` branch as we are now
+using `GitHub flow <https://guides.github.com/introduction/flow/>`_ for development.
 
 For style guidelines, please see the `HACKING <HACKING.rst>`_ document in the
 root of this repository.

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,15 +1,11 @@
 Contributing to pyrax
 =====================
 
-Please create all pull requests against the 'working' branch. The
-'master' branch is reserved for full releases, complete with updated
-docs, etc.
+Please create all pull requests against the 'master' branch.
 
 For ease of testing, please ensure that the ``tox`` module is installed.
 
-While PEP8 is generally followed, it is not treated as Holy Gospel.
-Practicality beats purity, and coming up with some convoluted coding to
-avoid a line of 82 characters is an anti-pattern.
+We follow PEP8 standards with the exception of line length of 84 characters.
 
 When indenting continuation lines, the standard is 2 levels (i.e., 8
 spaces). Please do not use "visual indentation", as it is fraught with

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -768,7 +768,23 @@ def connect_to_cloud_databases(region=None):
 
 def connect_to_cloud_cdn(region=None):
     """Creates a client for working with cloud loadbalancers."""
-    return _create_client(ep_name="cdn", region=region)
+    global default_region
+    # (nicholaskuechler/keekz) 2017-11-30 - Not a very elegant solution...
+    # Cloud CDN only exists in 2 regions: DFW and LON
+    # But this isn't playing nicely with the identity service catalog results.
+    # US auth based regions (DFW, ORD, IAD, SYD, HKG) need to use CDN in DFW
+    # UK auth based regions (LON) need to use CDN in LON
+    if region in ['DFW', 'IAD', 'ORD', 'SYD', 'HKG']:
+        return _create_client(ep_name="cdn", region="DFW")
+    elif region in ['LON']:
+        return _create_client(ep_name="cdn", region="LON")
+    else:
+        if default_region in ['DFW', 'IAD', 'ORD', 'SYD', 'HKG']:
+            return _create_client(ep_name="cdn", region="DFW")
+        elif default_region in ['LON']:
+            return _create_client(ep_name="cdn", region="LON")
+        else:
+            return _create_client(ep_name="cdn", region=region)
 
 
 def connect_to_cloud_loadbalancers(region=None):

--- a/pyrax/resource.py
+++ b/pyrax/resource.py
@@ -68,7 +68,7 @@ class BaseResource(object):
         corresponding attributes on the object.
         """
         for (key, val) in six.iteritems(info):
-            if isinstance(key, six.text_type):
+            if isinstance(key, six.text_type) and six.PY2:
                 key = key.encode(pyrax.get_encoding())
             elif isinstance(key, bytes):
                 key = key.decode("utf-8")


### PR DESCRIPTION
Using a `working` branch is counterproductive for several reasons:

1. Git tags exist for the purposes of tracking blessed releases.
2. GitHub defaults the PR to merge against the master branch unless
   we change the default branch, when then confuses users because
   the released current version is on a non-default branch.
3. GitHub flow is more commonly used in open-source projects AFAIK.

This branch also merges the contents of the `working` branch in order to bring the two in sync.

I'm requesting reviews from all my fellow new maintainers (somehow @cardoe didn't get included there) in the hopes of building a consensus before this gets merged.