### PR TITLE
Ignore typical names for virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ rpms/
 .coveralls.yml
 .coverage
 pyrax.spec
+
+.venv/
+env/
+venv/


### PR DESCRIPTION
Trivial PR: just add some common names for virtualenvs to .gitignore.