### PR TITLE
Don't tell people to use sudo if they're not using a virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ you can install directly from trunk on GitHub:
 
 If you are not using
 `virtualenv <http://pypi.python.org/pypi/virtualenv>`_, you will need to
-run ``pip install`` as admin using ``sudo``.
+run ``pip install --user`` to install into your user account's site packages.
 
 You may also download and install from source. The source code for
 **pyrax** is available on


### PR DESCRIPTION
The pip maintainers [added](https://github.com/pypa/pip/commit/614059007f4fe440f0aa0a2ac463e7749cfc1528) the `--user` flag in 2017, so let's take advantage of that.