### PR TITLE
Fix sporadically failing test

### DIFF
--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -1060,9 +1060,9 @@ class ObjectStorageTest(unittest.TestCase):
     def test_cmgr_get_temp_url_unicode_error(self):
         cont = self.container
         mgr = cont.manager
-        obj = utils.random_unicode()
+        obj = utils.random_unicode() + u'💯'
         seconds = random.randint(1, 1000)
-        key = utils.random_unicode()
+        key = utils.random_unicode() + u'💯'
         method = "GET"
         mgr.api.management_url = "%s/v2/" % fakes.example_uri
         self.assertRaises(exc.UnicodePathError, mgr.get_temp_url, cont,
@@ -2390,8 +2390,8 @@ class ObjectStorageTest(unittest.TestCase):
                 "%s%s" % (ACCOUNT_META_PREFIX, key_exclude): val_exclude}
         mgr.get_account_headers = Mock(return_value=headers)
         ret = clt.get_account_details()
-        self.assertTrue(key_include in ret)
-        self.assertFalse(key_exclude in ret)
+        self.assertIn(key_include.replace('-', '_'), ret)
+        self.assertNotIn(key_exclude.replace('-', '_'), ret)
 
     def test_clt_get_account_info(self):
         clt = self.client

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -117,7 +117,7 @@ class UtilsTest(unittest.TestCase):
     def test_random_unicode(self):
         testlen = random.randint(50, 500)
         nm = utils.random_unicode(testlen)
-        self.assertEqual(len(nm), testlen)
+        self.assertEqual(len(nm), testlen, (nm, testlen, len(nm)))
 
     def test_folder_size_bad_folder(self):
         self.assertRaises(exc.FolderNotFound, utils.folder_size,


### PR DESCRIPTION
Fix one test which is guaranteed to fail any time a random string comes up with a hyphen in it (roughly 1 in 976 chance of that happening)

Tested locally on py27, py34, py35, and py36.

Fixes #647 