### PR TITLE
Nojira fix nova deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pyrax.spec
 .venv/
 env/
 venv/
+.idea

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -117,7 +117,7 @@ regions = tuple()
 services = tuple()
 
 _client_classes = {
-        "compute": _cs_client.get_client_class(_cs_max_version),
+        "compute": _cs_client.Client(_cs_max_version),
         "cdn": CloudCDNClient,
         "object_store": StorageClient,
         "database": CloudDatabaseClient,

--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -678,8 +678,7 @@ def connect_to_cloudservers(region=None, context=None, verify_ssl=None, **kwargs
         extensions = nc.discover_extensions(_cs_max_version)
     except AttributeError:
         extensions = None
-    clt_class = _cs_client.get_client_class(_cs_max_version)
-    cloudservers = clt_class(context.username, context.password,
+    cloudservers = nc.Client(2, context.username, context.password,
             project_id=context.tenant_id, auth_url=context.auth_endpoint,
             auth_system=id_type, region_name=region, service_type="compute",
             auth_plugin=auth_plugin, insecure=insecure, extensions=extensions,

--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -574,12 +574,12 @@ class Container(BaseResource):
         return self.manager.delete_object_in_seconds(self, obj, seconds)
 
 
-    def delete_all_objects(self, async_=False):
+    def delete_all_objects(self, asynchronous=False):
         """
         Deletes all objects from this container.
 
         By default the call will block until all objects have been deleted. By
-        passing True for the 'async_' parameter, this method will not block, and
+        passing True for the 'asynchronous' parameter, this method will not block, and
         instead return an object that can be used to follow the progress of the
         deletion. When deletion is complete the bulk deletion object's
         'results' attribute will be populated with the information returned
@@ -593,7 +593,7 @@ class Container(BaseResource):
             errors - a list of any errors returned by the bulk delete call
         """
         nms = self.list_object_names(full_listing=True)
-        return self.object_manager.delete_all_objects(nms, async_=async_)
+        return self.object_manager.delete_all_objects(nms, asynchronous=asynchronous)
 
 
     def copy_object(self, obj, new_container, new_obj_name=None,
@@ -852,7 +852,7 @@ class ContainerManager(BaseManager):
         """
         if del_objects:
             nms = self.list_object_names(container, full_listing=True)
-            self.api.bulk_delete(container, nms, async_=False)
+            self.api.bulk_delete(container, nms, asynchronous=False)
         uri = "/%s" % utils.get_name(container)
         resp, resp_body = self.api.method_delete(uri)
 
@@ -2028,12 +2028,12 @@ class StorageObjectManager(BaseManager):
         return super(StorageObjectManager, self).delete(obj)
 
 
-    def delete_all_objects(self, nms, async_=False):
+    def delete_all_objects(self, nms, asynchronous=False):
         """
         Deletes all objects from this container.
 
         By default the call will block until all objects have been deleted. By
-        passing True for the 'async_' parameter, this method will not block, and
+        passing True for the 'asynchronous' parameter, this method will not block, and
         instead return an object that can be used to follow the progress of the
         deletion. When deletion is complete the bulk deletion object's
         'results' attribute will be populated with the information returned
@@ -2048,7 +2048,7 @@ class StorageObjectManager(BaseManager):
         """
         if nms is None:
             nms = self.api.list_object_names(self.name, full_listing=True)
-        return self.api.bulk_delete(self.name, nms, async_=async_)
+        return self.api.bulk_delete(self.name, nms, asynchronous=asynchronous)
 
 
     @_handle_object_not_found
@@ -3161,17 +3161,17 @@ class StorageClient(BaseClient):
         self._sync_summary["deleted"] += len(to_delete)
         # We don't need to wait around for this to complete. Store the thread
         # reference in case it is needed at some point.
-        self._thread = self.bulk_delete(cont, to_delete, async_=True)
+        self._thread = self.bulk_delete(cont, to_delete, asynchronous=True)
 
 
-    def bulk_delete(self, container, object_names, async_=False):
+    def bulk_delete(self, container, object_names, asynchronous=False):
         """
         Deletes multiple objects from a container in a single call.
 
         The bulk deletion call does not return until all of the specified
         objects have been processed. For large numbers of objects, this can
-        take quite a while, so there is an 'async_' parameter to give you the
-        option to have this call return immediately. If 'async_' is True, an
+        take quite a while, so there is an 'asynchronous' parameter to give you the
+        option to have this call return immediately. If 'asynchronous' is True, an
         object is returned with a 'completed' attribute that will be set to
         True as soon as the bulk deletion is complete, and a 'results'
         attribute that will contain a dictionary (described below) with the
@@ -3192,7 +3192,7 @@ class StorageClient(BaseClient):
         """
         deleter = BulkDeleter(self, container, object_names)
         deleter.start()
-        if async_:
+        if asynchronous:
             return deleter
         while not deleter.completed:
             time.sleep(self.bulk_delete_interval)

--- a/pyrax/version.py
+++ b/pyrax/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-version = "1.9.8"
+version = "1.9.9"

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "python-novaclient==2.27.0",
+        "python-novaclient==5.0.0",
         "rackspace-novaclient",
         "keyring",
         "requests>=2.2.1,<3",


### PR DESCRIPTION
Just as it says on the tin, fix this warning:
```
/usr/local/lib/python3.6/dist-packages/novaclient/client.py:831: UserWarning: 'get_client_class' is deprecated. Please use `novaclient.client.Client` instead.
  warnings.warn(_LW("'get_client_class' is deprecated. "
```