### PR TITLE
add GitHub Actions workflow to upload releases

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -1,0 +1,28 @@
+name: pypi_upload
+
+on:
+  release:
+    types: created
+
+jobs:
+  build:
+    name: PyPI Upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install latest pip, setuptools, twine + wheel
+        run: |
+          python -m pip install --upgrade pip setuptools twine wheel
+      - name: Build wheels
+        run: |
+          python setup.py bdist_wheel
+          python setup.py sdist
+      - name: Upload to PyPI via Twine
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload --verbose -u '__token__' dist/*


### PR DESCRIPTION
Wire up the necessary bits to upload releases from a GitHub Actions
workflow. Copied code from https://github.com/psf/black