### PR TITLE
bump the version and mark the wheel as universal

### DIFF
--- a/pyrax/version.py
+++ b/pyrax/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-version = "1.9.8"
+version = "1.10.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ max-line-length=84
 exclude=build,.eggs,.tox,tests,samples
 statistics=yes
 ignore=E123,E124,E126,E127,E128,E303,E302,W606,F841,E301,F401,E305,W504,W605,F403,F405,E999
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The same wheel will work for Python 2 and Python 3 so mark it as such. Bump the version to 1.10.0