### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/cloud_files.md
+++ b/docs/cloud_files.md
@@ -203,7 +203,7 @@ Since Cloud Files does not have a hierarchical folder structure, you can simulat
 
 …you would typically create a container named 'base', and when uploading the file 'three.txt', you would give it the name 'one/two/three.txt'. There really isn't any such structure inside that container, but it helps you to track the relation of files to their original directory structure.
 
-When you retieve the file from Cloud Files, it's helpful to retain that structure on your disk. Like the other methods, there are three ways to do this. If you have a `StorageObject` reference for the object you want to download, just call its `download()` method. If you have the `Container` object that holds the stored object, call its `downlod_object()` method, passing in the name of the object to fetch. Finally, you can call the `pyrax.cloudfiles.download_object()` method, passing in the container and object names. On all three, you also need to pass in the full path to the local directory in which the file is written. That directory must exist on your disk before you attempt to download files to it.
+When you retrieve the file from Cloud Files, it's helpful to retain that structure on your disk. Like the other methods, there are three ways to do this. If you have a `StorageObject` reference for the object you want to download, just call its `download()` method. If you have the `Container` object that holds the stored object, call its `downlod_object()` method, passing in the name of the object to fetch. Finally, you can call the `pyrax.cloudfiles.download_object()` method, passing in the container and object names. On all three, you also need to pass in the full path to the local directory in which the file is written. That directory must exist on your disk before you attempt to download files to it.
 
 These commands take an optional parameter named `structure`. When `True` (the default if omitted), the folder structure of your object name is recreated on your disk. If for any reason you don't want this done, simply set this to `False`, and the objects are all stored in the same base directory without any regard to any paths in their names.
 
@@ -447,7 +447,7 @@ Cloud Files makes it easy to publish your stored objects over the high-speed Aka
 
 ### CDN default web pages
 
-You can set a static web page as the landing page for you CND-enabled containter by calling:
+You can set a static web page as the landing page for you CND-enabled container by calling:
 
     cont.set_web_index_page("example-index.html")
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -123,7 +123,7 @@ Please note that if you used `auth_with_token()` to authenticate originally, pyr
 
 
 ## Pyrax Configuration
-You can control how pyrax behaves through the configuration file. It should be named `~/.pyrax.cfg`. Like the credential file, `~/.pyrax.cfg` is a standard configuration file. Alternatively, you may set these values using environment variables in the OS. Note that the configuration file values take precendence over any environment variables. Environment variables also do not support multiple configurations.
+You can control how pyrax behaves through the configuration file. It should be named `~/.pyrax.cfg`. Like the credential file, `~/.pyrax.cfg` is a standard configuration file. Alternatively, you may set these values using environment variables in the OS. Note that the configuration file values take precedence over any environment variables. Environment variables also do not support multiple configurations.
 
 **Do not include login credentials**, such as passwords, in the configuration file. As this is a defined file in a known location, it is a security risk to have your login information stored in clear text. You may use a [credential file](#authenticating) if you wish to store your credentials on disk; this can be named whatever you wish, and placed anywhere on disk, since you pass the full path to the file when authenticating this way. Please note that credentials stored in the configuration file will be ignored, and a warning will be issued if they are found.
 
@@ -193,9 +193,9 @@ If the environment is then changed to 'public', pyrax switches to Rackspace auth
 
 
 ### Accessing Environment Information
-Pyrax offers several methods for querying and modifying environments and their settings. To start, you can determine the current environment by calling `pyrax.get_environment()`. You can also get a list of all defined environments by calling `pyrax.list_environments()`. And as mentioned above, you can switch the current envrionment by calling `pyrax.set_environment(new_env_name)`.
+Pyrax offers several methods for querying and modifying environments and their settings. To start, you can determine the current environment by calling `pyrax.get_environment()`. You can also get a list of all defined environments by calling `pyrax.list_environments()`. And as mentioned above, you can switch the current environment by calling `pyrax.set_environment(new_env_name)`.
 
-To get the value of a setting, call `pyrax.get_setting(key)`. Normally you do not need to change settings in the middle of a session, but just in case you do, you can use the `pyrax.set_setting(key, val)` method. Both of these methods work on the current environment by default. You can get/set settings in other environments with those calls by passing in the envrionment name as the optional `env` parameter to those methods.
+To get the value of a setting, call `pyrax.get_setting(key)`. Normally you do not need to change settings in the middle of a session, but just in case you do, you can use the `pyrax.set_setting(key, val)` method. Both of these methods work on the current environment by default. You can get/set settings in other environments with those calls by passing in the environment name as the optional `env` parameter to those methods.
 
 
 ## Debugging HTTP requests

--- a/docs/images.md
+++ b/docs/images.md
@@ -46,7 +46,7 @@ Parameter | Effect
 **status** | Filter parameter that species the image status as 'queued', 'saving', 'active', 'killed', 'deleted', or 'pending_delete'.
 **size_min** | Filters images whose size **in bytes** is greater than or equal to this value.
 **size_max** | Filters images whose size **in bytes** is less than or equal to this value. 
-**sort_key** | Images by default are returned in order of their **created_at** value. You can specifiy any other attribute of an image to control the sorting with this parameter.
+**sort_key** | Images by default are returned in order of their **created_at** value. You can specify any other attribute of an image to control the sorting with this parameter.
 **sort_dir** | Sort direction. Valid values are 'asc' (ascending) and 'desc' (descending). The default is 'desc'.
 
 

--- a/pyrax/cloudcdn.py
+++ b/pyrax/cloudcdn.py
@@ -195,7 +195,7 @@ class CloudCDNClient(BaseClient):
         url: The URL at which to delete assets
         all: When True, delete all assets associated with the service_id.
 
-        You cannot specifiy both url and all.
+        You cannot specify both url and all.
         """
         self._services_manager.delete_assets(service_id, url, all)
 

--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -788,7 +788,7 @@ class ContainerManager(BaseManager):
     def list(self, limit=None, marker=None, end_marker=None, prefix=None):
         """
         Swift doesn't return listings in the same format as the rest of
-        OpenStack, so this method has to be overriden.
+        OpenStack, so this method has to be overridden.
         """
         uri = "/%s" % self.uri_base
         qs = utils.dict_to_qs({"marker": marker, "limit": limit,
@@ -819,7 +819,7 @@ class ContainerManager(BaseManager):
     def create(self, name, metadata=None, prefix=None, *args, **kwargs):
         """
         Creates a new container, and returns a Container object that represents
-        that contianer. If a container by the same name already exists, no
+        that container. If a container by the same name already exists, no
         exception is raised; instead, a reference to that existing container is
         returned.
         """

--- a/pyrax/queueing.py
+++ b/pyrax/queueing.py
@@ -129,7 +129,7 @@ class Queue(BaseResource):
 
         The 'marker' and 'limit' parameters are used to control pagination of
         results. 'Marker' is the ID of the last message returned, while 'limit'
-        controls the number of messages returned per reuqest (default=20).
+        controls the number of messages returned per request (default=20).
         """
         return self._message_manager.list(include_claimed=include_claimed,
                 echo=echo, marker=marker, limit=limit)
@@ -666,7 +666,7 @@ class QueueClient(BaseClient):
 
         The 'marker' and 'limit' parameters are used to control pagination of
         results. 'Marker' is the ID of the last message returned, while 'limit'
-        controls the number of messages returned per reuqest (default=20).
+        controls the number of messages returned per request (default=20).
         """
         return queue.list(include_claimed=include_claimed, echo=echo,
                 marker=marker, limit=limit)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -48,7 +48,7 @@ class UtilsTest(unittest.TestCase):
             self.assert_(isinstance(tmp, six.string_types))
             self.assert_(os.path.exists(tmp))
             self.assert_(os.path.isfile(tmp))
-        # File shoud be deleted after exiting the block
+        # File should be deleted after exiting the block
         self.assertFalse(os.path.exists(tmp))
 
     def test_self_deleting_temp_directory(self):
@@ -56,7 +56,7 @@ class UtilsTest(unittest.TestCase):
             self.assert_(isinstance(tmp, six.string_types))
             self.assert_(os.path.exists(tmp))
             self.assert_(os.path.isdir(tmp))
-        # Directory shoud be deleted after exiting the block
+        # Directory should be deleted after exiting the block
         self.assertFalse(os.path.exists(tmp))
 
     def test_dot_dict(self):


### PR DESCRIPTION
There are small typos in:
- docs/cloud_files.md
- docs/getting_started.md
- docs/images.md
- pyrax/cloudcdn.py
- pyrax/object_storage.py
- pyrax/queueing.py
- tests/unit/test_utils.py

Fixes:
- Should read `specify` rather than `specifiy`.
- Should read `should` rather than `shoud`.
- Should read `request` rather than `reuqest`.
- Should read `environment` rather than `envrionment`.
- Should read `retrieve` rather than `retieve`.
- Should read `precedence` rather than `precendence`.
- Should read `overridden` rather than `overriden`.
- Should read `container` rather than `contianer`.
- Should read `container` rather than `containter`.

Closes #662